### PR TITLE
debuged the footprints legoutside, added quad legoutside default `false`

### DIFF
--- a/src/fn/ms012.ts
+++ b/src/fn/ms012.ts
@@ -1,4 +1,4 @@
-import type { AnySoupElement } from "circuit-json"
+import type { AnyCircuitElement } from "circuit-json"
 import { extendSoicDef, soicWithoutParsing } from "./soic"
 import type { z } from "zod"
 
@@ -10,7 +10,7 @@ export const ms012_def = extendSoicDef({
 
 export const ms012 = (
   raw_params: z.input<typeof ms012_def>,
-): { circuitJson: AnySoupElement[]; parameters: any } => {
+): { circuitJson: AnyCircuitElement[]; parameters: any } => {
   const parameters = ms012_def.parse({ ...raw_params, num_pins: 8 })
   return {
     circuitJson: soicWithoutParsing(parameters),

--- a/src/fn/quad.ts
+++ b/src/fn/quad.ts
@@ -25,7 +25,7 @@ export const base_quad_def = z.object({
   pw: length.optional(),
   pl: length.optional(),
   thermalpad: z.union([z.literal(true), dim2d]).optional(),
-  legsoutside: z.boolean().optional(),
+  legsoutside: z.boolean().default(false),
 })
 
 export const quadTransform = <T extends z.infer<typeof base_quad_def>>(


### PR DESCRIPTION
/claim #106 

quad legoutside default `false` will fix the quad in snippet not having legsoutside checkbox.

CC @seveibar @ShiboSoftwareDev 
Not all footprints have both "legsOutside" and "no legsOutside" variants. Some, like QFP and QFN, are variants but differ in footprint designs (QFP with legsOutside and QFN with no legsoutside ). Others, such as MS012 and MS013 (extensions of SOIC), exist only with a legsOutside configuration.
so we will need to find a way or add parameter that say if this has a variant or not?
we can merge this and create an issue with what we should do.
![image](https://github.com/user-attachments/assets/570aea82-ca6a-4c2e-ab18-66ee58797b1c)
![image](https://github.com/user-attachments/assets/eccc2ef8-7c15-498d-8d8b-6b80360ea67f)
