### PR TITLE
ci: update GitHub Actions workflows to use latest versions

### DIFF
--- a/.github/workflows/bun-build.yml
+++ b/.github/workflows/bun-build.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
 

--- a/.github/workflows/bun-formatcheck.yml
+++ b/.github/workflows/bun-formatcheck.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
 

--- a/.github/workflows/bun-pver-release.yml
+++ b/.github/workflows/bun-pver-release.yml
@@ -8,9 +8,9 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
       - uses: actions/setup-node@v3

--- a/.github/workflows/bun-test.yml
+++ b/.github/workflows/bun-test.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
 

--- a/.github/workflows/formatbot.yml
+++ b/.github/workflows/formatbot.yml
@@ -21,12 +21,12 @@ jobs:
         fi
 
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         token: ${{ steps.check_fork.outputs.is_fork == 'true' && secrets.GITHUB_TOKEN || secrets.TSCIRCUIT_BOT_GITHUB_TOKEN }}
 
     - name: Setup Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: '20'
 


### PR DESCRIPTION
Update actions/checkout to v4, oven-sh/setup-bun to v2, and actions/setup-node to v4 to ensure compatibility and leverage the latest features and improvements.