### PR TITLE
Fix pad footprint json output

### DIFF
--- a/src/fn/pad.ts
+++ b/src/fn/pad.ts
@@ -12,7 +12,9 @@ export const pad_def = z.object({
 
 export type PadDef = z.input<typeof pad_def>
 
-export const pad = (params: PadDef): { circuitJson: AnySoupElement[] } => {
+export const pad = (
+  params: PadDef,
+): { circuitJson: AnySoupElement[]; parameters: PadDef } => {
   const { w, h } = params
   const width = mm(w)
   const height = mm(h)
@@ -22,5 +24,6 @@ export const pad = (params: PadDef): { circuitJson: AnySoupElement[] } => {
       rectpad(1, 0, 0, width, height),
       silkscreenRef(0, height / 2 + 0.5, 0.2),
     ],
+    parameters: params,
   }
 }

--- a/tests/pad.test.ts
+++ b/tests/pad.test.ts
@@ -37,6 +37,8 @@ test("pad footprint", async () => {
 ]
 `)
   snapshotSoup(soup)
+  const params = fp().pad().w(2).h(1).json()
+  expect(params).toMatchObject({ w: 2, h: 1 })
 })
 
 test("pad footprint with different dimensions", async () => {
@@ -74,4 +76,6 @@ test("pad footprint with different dimensions", async () => {
 ]
 `)
   snapshotSoup(soup)
+  const params = fp().pad().w(3).h(2).json()
+  expect(params).toMatchObject({ w: 3, h: 2 })
 })


### PR DESCRIPTION
## Summary
- ensure `pad()` returns parameters alongside circuit JSON
- verify pad parameters in pad unit tests

## Testing
- `npm test` *(fails: Cannot find package 'bun-match-svg' & other errors)*

------
https://chatgpt.com/codex/tasks/task_e_684ef4170c4c83288088734403171083