### PR TITLE
Add origin property for pad offsets

### DIFF
--- a/src/footprinter.ts
+++ b/src/footprinter.ts
@@ -4,6 +4,7 @@ import type { AnyCircuitElement } from "circuit-json"
 import type { AnyFootprinterDefinitionOutput } from "./helpers/zod/AnyFootprinterDefinitionOutput"
 import { isNotNull } from "./helpers/is-not-null"
 import { footprintSizes } from "./helpers/passive-fn"
+import { applyOrigin } from "./helpers/apply-origin"
 
 export type FootprinterParamsBuilder<K extends string> = {
   [P in K | "params" | "soup" | "circuitJson"]: P extends
@@ -295,7 +296,10 @@ export const footprinter = (): Footprinter & {
       get: (target: any, prop: string) => {
         if (prop === "soup" || prop === "circuitJson") {
           if ("fn" in target && FOOTPRINT_FN[target.fn]) {
-            return () => FOOTPRINT_FN[target.fn](target).circuitJson
+            return () => {
+              const { circuitJson } = FOOTPRINT_FN[target.fn](target)
+              return applyOrigin(circuitJson, target.origin)
+            }
           }
 
           if (!FOOTPRINT_FN[target.fn]) {

--- a/src/helpers/apply-origin.ts
+++ b/src/helpers/apply-origin.ts
@@ -1,0 +1,111 @@
+export type OriginMode =
+  | "center"
+  | "bottomleft"
+  | "pin1"
+  | "bottomcenter"
+  | "centerbottom"
+  | "topcenter"
+  | "centertop"
+  | "leftcenter"
+  | "centerleft"
+  | "rightcenter"
+  | "centerright"
+
+import type { AnySoupElement } from "circuit-json"
+
+export const applyOrigin = (
+  elements: AnySoupElement[],
+  origin: OriginMode | undefined,
+): AnySoupElement[] => {
+  if (!origin) return elements
+
+  const pads = elements.filter(
+    (el) =>
+      el.type === "pcb_smtpad" ||
+      el.type === "pcb_plated_hole" ||
+      el.type === "pcb_thtpad",
+  ) as Array<any>
+
+  if (pads.length === 0) return elements
+
+  let minX = Infinity
+  let maxX = -Infinity
+  let minY = Infinity
+  let maxY = -Infinity
+
+  const updateBounds = (x: number, y: number, w = 0, h = 0) => {
+    const left = x - w / 2
+    const right = x + w / 2
+    const bottom = y - h / 2
+    const top = y + h / 2
+    minX = Math.min(minX, left)
+    maxX = Math.max(maxX, right)
+    minY = Math.min(minY, bottom)
+    maxY = Math.max(maxY, top)
+  }
+
+  for (const pad of pads) {
+    if (pad.type === "pcb_smtpad") {
+      const w = pad.shape === "circle" ? pad.radius * 2 : pad.width
+      const h = pad.shape === "circle" ? pad.radius * 2 : pad.height
+      updateBounds(pad.x, pad.y, w, h)
+    } else if (pad.type === "pcb_plated_hole") {
+      const d = pad.outer_diameter ?? pad.hole_diameter
+      updateBounds(pad.x, pad.y, d, d)
+    } else if (pad.type === "pcb_thtpad") {
+      const d = pad.diameter
+      updateBounds(pad.x, pad.y, d, d)
+    }
+  }
+
+  let dx = 0
+  let dy = 0
+  switch (origin) {
+    case "center":
+      dx = (minX + maxX) / 2
+      dy = (minY + maxY) / 2
+      break
+    case "bottomleft":
+      dx = minX
+      dy = minY
+      break
+    case "bottomcenter":
+    case "centerbottom":
+      dx = (minX + maxX) / 2
+      dy = minY
+      break
+    case "topcenter":
+    case "centertop":
+      dx = (minX + maxX) / 2
+      dy = maxY
+      break
+    case "leftcenter":
+    case "centerleft":
+      dx = minX
+      dy = (minY + maxY) / 2
+      break
+    case "rightcenter":
+    case "centerright":
+      dx = maxX
+      dy = (minY + maxY) / 2
+      break
+    case "pin1":
+      const pin1 = pads.find((p) => p.port_hints?.[0] === "1") || pads[0]
+      dx = pin1.x
+      dy = pin1.y
+      break
+  }
+
+  if (dx === 0 && dy === 0) return elements
+
+  for (const pad of pads) {
+    pad.x -= dx
+    pad.y -= dy
+    if (pad.center) {
+      pad.center.x -= dx
+      pad.center.y -= dy
+    }
+  }
+
+  return elements
+}

--- a/tests/origin.test.ts
+++ b/tests/origin.test.ts
@@ -1,0 +1,112 @@
+import { test, expect } from "bun:test"
+import { fp } from "../src/footprinter"
+
+// Test bottomleft origin for single pad
+
+test("smtpad origin bottomleft", () => {
+  const circuit = fp()
+    .smtpad()
+    .rect()
+    .w("2mm")
+    .h("1mm")
+    .origin("bottomleft")
+    .circuitJson()
+  const pad = circuit[0]
+  expect(pad.x).toBeCloseTo(1)
+  expect(pad.y).toBeCloseTo(0.5)
+})
+
+// Test pin1 origin for resistor
+
+test("res origin pin1", () => {
+  const circuit = fp().res().imperial("0603").origin("pin1").circuitJson()
+  const pad1 = circuit.find(
+    (el) => el.type === "pcb_smtpad" && el.port_hints?.[0] === "1",
+  )
+  expect(pad1?.x).toBeCloseTo(0)
+  expect(pad1?.y).toBeCloseTo(0)
+})
+
+// Test bottomcenter and centerbottom origins
+
+test("smtpad origin bottomcenter", () => {
+  const circuit = fp()
+    .smtpad()
+    .rect()
+    .w("2mm")
+    .h("1mm")
+    .origin("bottomcenter")
+    .circuitJson()
+  const pad = circuit[0]
+  expect(pad.x).toBeCloseTo(0)
+  expect(pad.y).toBeCloseTo(0.5)
+})
+
+test("smtpad origin centerbottom", () => {
+  const circuit = fp()
+    .smtpad()
+    .rect()
+    .w("2mm")
+    .h("1mm")
+    .origin("centerbottom")
+    .circuitJson()
+  const pad = circuit[0]
+  expect(pad.x).toBeCloseTo(0)
+  expect(pad.y).toBeCloseTo(0.5)
+})
+
+// Test leftcenter alias centerleft
+
+test("smtpad origin leftcenter", () => {
+  const circuit = fp()
+    .smtpad()
+    .rect()
+    .w("2mm")
+    .h("1mm")
+    .origin("leftcenter")
+    .circuitJson()
+  const pad = circuit[0]
+  expect(pad.x).toBeCloseTo(1)
+  expect(pad.y).toBeCloseTo(0)
+})
+
+test("smtpad origin centerleft", () => {
+  const circuit = fp()
+    .smtpad()
+    .rect()
+    .w("2mm")
+    .h("1mm")
+    .origin("centerleft")
+    .circuitJson()
+  const pad = circuit[0]
+  expect(pad.x).toBeCloseTo(1)
+  expect(pad.y).toBeCloseTo(0)
+})
+
+// Top/centertop
+
+test("smtpad origin topcenter", () => {
+  const circuit = fp()
+    .smtpad()
+    .rect()
+    .w("2mm")
+    .h("1mm")
+    .origin("topcenter")
+    .circuitJson()
+  const pad = circuit[0]
+  expect(pad.x).toBeCloseTo(0)
+  expect(pad.y).toBeCloseTo(-0.5)
+})
+
+test("smtpad origin centertop", () => {
+  const circuit = fp()
+    .smtpad()
+    .rect()
+    .w("2mm")
+    .h("1mm")
+    .origin("centertop")
+    .circuitJson()
+  const pad = circuit[0]
+  expect(pad.x).toBeCloseTo(0)
+  expect(pad.y).toBeCloseTo(-0.5)
+})


### PR DESCRIPTION
## Summary
- add helper to translate pads according to origin
- apply origin translation for soup/circuitJson
- test origin modes
- support center-bottom and other origin directions

## Testing
- `bun test tests/origin.test.ts`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_6887f1b6d7a0832e8a30f22abf0a39c8