### PR TITLE
Add nosilkscreen option to base footprint params

### DIFF
--- a/src/footprinter.ts
+++ b/src/footprinter.ts
@@ -6,9 +6,17 @@ import { isNotNull } from "./helpers/is-not-null"
 import { footprintSizes } from "./helpers/passive-fn"
 import { applyOrigin } from "./helpers/apply-origin"
 import { applyNoRefDes } from "./helpers/apply-norefdes"
+import { applyNoSilkscreen } from "./helpers/apply-nosilkscreen"
+
+type BaseOptionKey =
+  | "origin"
+  | "norefdes"
+  | "invert"
+  | "faceup"
+  | "nosilkscreen"
 
 export type FootprinterParamsBuilder<K extends string> = {
-  [P in K | "params" | "soup" | "circuitJson"]: P extends
+  [P in K | BaseOptionKey | "params" | "soup" | "circuitJson"]: P extends
     | "params"
     | "soup"
     | "circuitJson"
@@ -312,10 +320,15 @@ export const footprinter = (): Footprinter & {
           if ("fn" in target && FOOTPRINT_FN[target.fn]) {
             return () => {
               const { circuitJson } = FOOTPRINT_FN[target.fn](target)
-              return applyOrigin(
-                applyNoRefDes(circuitJson, target),
-                target.origin,
+              const circuitWithoutSilkscreen = applyNoSilkscreen(
+                circuitJson,
+                target,
               )
+              const circuitWithoutRefDes = applyNoRefDes(
+                circuitWithoutSilkscreen,
+                target,
+              )
+              return applyOrigin(circuitWithoutRefDes, target.origin)
             }
           }
 

--- a/src/helpers/apply-nosilkscreen.ts
+++ b/src/helpers/apply-nosilkscreen.ts
@@ -1,0 +1,15 @@
+import type { AnyCircuitElement } from "circuit-json"
+
+export const applyNoSilkscreen = (
+  elements: AnyCircuitElement[],
+  parameters: any,
+): AnyCircuitElement[] => {
+  if (!parameters.nosilkscreen) return elements
+
+  return elements.filter((element) => {
+    return (
+      element.type !== "pcb_silkscreen_path" &&
+      element.type !== "pcb_silkscreen_text"
+    )
+  })
+}

--- a/src/helpers/zod/base_def.ts
+++ b/src/helpers/zod/base_def.ts
@@ -13,4 +13,8 @@ export const base_def = z.object({
     .boolean()
     .optional()
     .describe("The male pin header should face upwards, out of the top layer"),
+  nosilkscreen: z
+    .boolean()
+    .optional()
+    .describe("omit all silkscreen elements from the footprint"),
 })

--- a/tests/nosilkscreen.test.ts
+++ b/tests/nosilkscreen.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from "bun:test"
+import { fp } from "src/footprinter"
+
+test("nosilkscreen removes all silkscreen elements", () => {
+  const baseFootprint = fp()
+    .bga(8)
+    .w("4mm")
+    .h("4mm")
+    .grid("3x3")
+    .p(1)
+    .circuitJson()
+
+  expect(baseFootprint.some((el) => el.type.startsWith("pcb_silkscreen"))).toBe(
+    true,
+  )
+
+  const noSilkscreenFootprint = fp()
+    .bga(8)
+    .w("4mm")
+    .h("4mm")
+    .grid("3x3")
+    .p(1)
+    .nosilkscreen(true)
+    .circuitJson()
+
+  expect(
+    noSilkscreenFootprint.some((el) => el.type.startsWith("pcb_silkscreen")),
+  ).toBe(false)
+})


### PR DESCRIPTION
## Summary
- add a `nosilkscreen` flag to the shared footprint definition options
- filter generated footprints to remove silkscreen elements when the flag is set
- add coverage to ensure silkscreen elements are removed when requested

## Testing
- bun test tests/nosilkscreen.test.ts
- bunx tsc --noEmit (fails due to existing type errors)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692bc93e4f9c832ead4baf92b163f2b2)