### PR TITLE
Fix type error by adding missing hole_offset_x and hole_offset_y to PcbHoleCircularWithRectPad

### DIFF
--- a/src/helpers/platedHoleWithRectPad.ts
+++ b/src/helpers/platedHoleWithRectPad.ts
@@ -25,7 +25,7 @@ export const platedHoleWithRectPad = (
     pcb_port_id: "",
     layers: ["top", "bottom"],
     port_hints: [pn.toString()],
-    hole_offset_x,
-    hole_offset_y,
+    hole_offset_x: holeOffsetX,
+    hole_offset_y: holeOffsetY,
   }
 }


### PR DESCRIPTION
`
Type '{ pcb_plated_hole_id: string; type: "pcb_plated_hole"; shape: "circular_hole_with_rect_pad"; x: number; y: number; hole_diameter: number; hole_shape: "circle"; pad_shape: "rect"; rect_pad_width: number; rect_pad_height: number; pcb_port_id: string; layers: ("top" | "bottom")[]; port_hints: string[]; }' is missing the following properties from type 'PcbHoleCircularWithRectPad': hole_offset_x, hole_offset_yts(2739)
`