### PR TITLE
refactor: update platedHoleWithRectPad function calls to use options object

### DIFF
--- a/src/fn/dip.ts
+++ b/src/fn/dip.ts
@@ -116,14 +116,14 @@ export const dip = (raw_params: {
     )
     if (i === 0 && !parameters.nosquareplating) {
       platedHoles.push(
-        platedHoleWithRectPad(
-          i + 1,
+        platedHoleWithRectPad({
+          pn: i + 1,
           x,
           y,
-          parameters.id ?? "0.8mm",
-          parameters.od ?? "1mm",
-          parameters.od ?? "1mm",
-        ),
+          holeDiameter: parameters.id ?? "0.8mm",
+          rectPadWidth: parameters.od ?? "1mm",
+          rectPadHeight: parameters.od ?? "1mm",
+        }),
       )
       continue
     }

--- a/src/fn/jst.ts
+++ b/src/fn/jst.ts
@@ -83,8 +83,26 @@ function generatePads(
 
   if (variant === "ph") {
     const half_p = p / 2
-    pads.push(platedHoleWithRectPad(1, -half_p, 2, id, pw, pl))
-    pads.push(platedHoleWithRectPad(2, half_p, 2, id, pw, pl))
+    pads.push(
+      platedHoleWithRectPad({
+        pn: 1,
+        x: -half_p,
+        y: 2,
+        holeDiameter: id,
+        rectPadWidth: pw,
+        rectPadHeight: pl,
+      }),
+    )
+    pads.push(
+      platedHoleWithRectPad({
+        pn: 2,
+        x: half_p,
+        y: 2,
+        holeDiameter: id,
+        rectPadWidth: pw,
+        rectPadHeight: pl,
+      }),
+    )
   } else {
     const startX = -((numPins - 1) / 2) * p
     for (let i = 0; i < numPins; i++) {

--- a/src/fn/pinrow.ts
+++ b/src/fn/pinrow.ts
@@ -133,7 +133,16 @@ export const pinrow = (
   const addPin = (pinNumber: number, xoff: number, yoff: number) => {
     if (pinNumber === 1 && !parameters.nosquareplating) {
       // Always use square plating for pin 1 (no need to check nosquareplating anymore)
-      holes.push(platedHoleWithRectPad(pinNumber, xoff, yoff, id, od, od))
+      holes.push(
+        platedHoleWithRectPad({
+          pn: pinNumber,
+          x: xoff,
+          y: yoff,
+          holeDiameter: id,
+          rectPadWidth: od,
+          rectPadHeight: od,
+        }),
+      )
     } else {
       // Other pins with standard circular pad
       holes.push(platedhole(pinNumber, xoff, yoff, id, od))

--- a/src/fn/platedhole.ts
+++ b/src/fn/platedhole.ts
@@ -50,7 +50,14 @@ export const platedhole = (
   return {
     circuitJson: [
       squarepad
-        ? (platedHoleWithRectPad(1, 0, 0, d, pd, pd) as AnyCircuitElement)
+        ? (platedHoleWithRectPad({
+            pn: 1,
+            x: 0,
+            y: 0,
+            holeDiameter: d,
+            rectPadWidth: pd,
+            rectPadHeight: pd,
+          }) as AnyCircuitElement)
         : (makePlatedHole(1, 0, 0, d, pd) as AnyCircuitElement),
       silkscreenRef(0, pd / 2 + 0.5, 0.2) as AnyCircuitElement,
     ],

--- a/src/fn/to92.ts
+++ b/src/fn/to92.ts
@@ -39,7 +39,16 @@ export const to92_2 = (parameters: z.infer<typeof to92_def>) => {
   const padSpacing = Number.parseFloat(p)
 
   return [
-    platedHoleWithRectPad(1, -padSpacing, holeY - padSpacing, id, od, od, 0, 0),
+    platedHoleWithRectPad({
+      pn: 1,
+      x: -padSpacing,
+      y: holeY - padSpacing,
+      holeDiameter: id,
+      rectPadWidth: od,
+      rectPadHeight: od,
+      holeOffsetX: 0,
+      holeOffsetY: 0,
+    }),
     platedhole(2, padSpacing, holeY - padSpacing, id, od),
   ]
 }
@@ -72,16 +81,16 @@ export const to92 = (
   if (parameters.num_pins === 3) {
     if (inline) {
       platedHoles = [
-        platedHoleWithRectPad(
-          1,
-          -padSpacing,
-          holeY - padSpacing,
-          holeDia,
-          padDia,
-          padHeight,
-          0,
-          0,
-        ),
+        platedHoleWithRectPad({
+          pn: 1,
+          x: -padSpacing,
+          y: holeY - padSpacing,
+          holeDiameter: holeDia,
+          rectPadWidth: padDia,
+          rectPadHeight: padHeight,
+          holeOffsetX: 0,
+          holeOffsetY: 0,
+        }),
         platedHolePill(2, 0, holeY - padSpacing, holeDia, padWidth, padHeight),
         platedHolePill(
           3,
@@ -94,32 +103,30 @@ export const to92 = (
       ]
     } else {
       platedHoles = [
-        platedHoleWithRectPad(
-          1,
-          -padSpacing,
-          holeY - padSpacing,
-          holeDia,
-          padDia,
-          padDia,
-          0,
-          0,
-        ),
+        platedHoleWithRectPad({
+          pn: 1,
+          x: -padSpacing,
+          y: holeY - padSpacing,
+          holeDiameter: holeDia,
+          rectPadWidth: padDia,
+          rectPadHeight: padDia,
+          holeOffsetX: 0,
+          holeOffsetY: 0,
+        }),
         platedhole(2, 0, holeY, holeDia, padDia),
         platedhole(3, padSpacing, holeY - padSpacing, holeDia, padDia),
       ]
     }
   } else if (parameters.num_pins === 2) {
     platedHoles = [
-      platedHoleWithRectPad(
-        1,
-        -padSpacing,
-        holeY - padSpacing,
-        holeDia,
-        padWidth,
-        padHeight,
-        0,
-        0,
-      ),
+      platedHoleWithRectPad({
+        pn: 1,
+        x: -padSpacing,
+        y: holeY - padSpacing,
+        holeDiameter: holeDia,
+        rectPadWidth: padWidth,
+        rectPadHeight: padHeight,
+      }),
       platedHolePill(
         2,
         padSpacing,

--- a/src/fn/to92l.ts
+++ b/src/fn/to92l.ts
@@ -30,7 +30,16 @@ export const to92l = (
   const padH = parameters.inline ? 1.5 : od
 
   const holes = [
-    platedHoleWithRectPad(1, 0, 0, parameters.id, od, padH, 0, 0),
+    platedHoleWithRectPad({
+      pn: 1,
+      x: 0,
+      y: 0,
+      holeDiameter: parameters.id,
+      rectPadWidth: od,
+      rectPadHeight: padH,
+      holeOffsetX: 0,
+      holeOffsetY: 0,
+    }),
     parameters.inline
       ? platedHolePill(2, p, 0, parameters.id, od, padH)
       : platedhole(2, p, p, parameters.id, od),

--- a/src/helpers/platedHoleWithRectPad.ts
+++ b/src/helpers/platedHoleWithRectPad.ts
@@ -1,16 +1,31 @@
 import { mm } from "@tscircuit/mm"
 import type { PcbHoleCircularWithRectPad } from "circuit-json"
 
+export interface PlatedHoleWithRectPadOptions {
+  pn: number
+  x: number
+  y: number
+  holeDiameter: number | string
+  rectPadWidth: number | string
+  rectPadHeight: number | string
+  holeOffsetX?: number
+  holeOffsetY?: number
+}
+
 export const platedHoleWithRectPad = (
-  pn: number,
-  x: number,
-  y: number,
-  holeDiameter: number | string,
-  rectPadWidth: number | string,
-  rectPadHeight: number | string,
-  holeOffsetX: number,
-  holeOffsetY: number,
+  options: PlatedHoleWithRectPadOptions,
 ): PcbHoleCircularWithRectPad => {
+  const {
+    pn,
+    x,
+    y,
+    holeDiameter,
+    rectPadWidth,
+    rectPadHeight,
+    holeOffsetX = 0,
+    holeOffsetY = 0,
+  } = options
+
   return {
     pcb_plated_hole_id: "",
     type: "pcb_plated_hole",


### PR DESCRIPTION
This pull request refactors the `platedHoleWithRectPad` helper and updates all usages across the codebase to use a single options object instead of positional arguments. This change improves code readability and reduces the chance of errors from misordered parameters, especially as the number of arguments has grown.

### Refactoring to use options object for `platedHoleWithRectPad`

**Helper function update:**

* Refactored `platedHoleWithRectPad` in `src/helpers/platedHoleWithRectPad.ts` to accept a single options object (`PlatedHoleWithRectPadOptions`) instead of multiple positional arguments, with default values for optional offsets.

**Codebase-wide usage updates:**

* Updated all usages of `platedHoleWithRectPad` in the following modules to use the new options object format:
  - `src/fn/dip.ts`
  - `src/fn/jst.ts`
  - `src/fn/pinrow.ts`
  - `src/fn/platedhole.ts`
  - `src/fn/to92.ts` [[1]](diffhunk://#diff-aa8fe3502ec85ade813c1cda06c3d4ebbabd61baecef29790f36b45499314ae3L42-R51) [[2]](diffhunk://#diff-aa8fe3502ec85ade813c1cda06c3d4ebbabd61baecef29790f36b45499314ae3L75-R93) [[3]](diffhunk://#diff-aa8fe3502ec85ade813c1cda06c3d4ebbabd61baecef29790f36b45499314ae3L97-R129)
  - `src/fn/to92l.ts`