### PR TITLE
refactor: rename PCBSMTPad to PcbSmtPad across the codebase

### DIFF
--- a/src/fn/bga.ts
+++ b/src/fn/bga.ts
@@ -1,4 +1,4 @@
-import type { AnySoupElement, PCBSMTPad } from "circuit-json"
+import type { AnySoupElement, PcbSmtPad } from "circuit-json"
 import { rectpad } from "../helpers/rectpad"
 import { circlepad } from "../helpers/circlepad"
 import { ALPHABET } from "../helpers/zod/ALPHABET"
@@ -74,7 +74,7 @@ export const bga = (
 
   pad ??= ball * 0.8
 
-  const pads: PCBSMTPad[] = []
+  const pads: PcbSmtPad[] = []
 
   const missing_pin_nums = (missing ?? []).filter((a) => typeof a === "number")
   const num_pins_missing = grid.x * grid.y - num_pins

--- a/src/helpers/pillpad.ts
+++ b/src/helpers/pillpad.ts
@@ -1,4 +1,4 @@
-import type { PCBSMTPad } from "circuit-json"
+import type { PcbSmtPad } from "circuit-json"
 
 export const pillpad = (
   pn: number | Array<string | number>,
@@ -6,7 +6,7 @@ export const pillpad = (
   y: number,
   w: number,
   h: number,
-): PCBSMTPad => {
+): PcbSmtPad => {
   return {
     type: "pcb_smtpad",
     x,

--- a/src/helpers/rectpad.ts
+++ b/src/helpers/rectpad.ts
@@ -1,11 +1,11 @@
-import type { PCBSMTPad } from "circuit-json"
+import type { PcbSmtPad } from "circuit-json"
 export const rectpad = (
   pn: number | Array<string | number>,
   x: number,
   y: number,
   w: number,
   h: number,
-): PCBSMTPad => {
+): PcbSmtPad => {
   return {
     type: "pcb_smtpad",
     x,

--- a/tests/bga.test.ts
+++ b/tests/bga.test.ts
@@ -1,7 +1,7 @@
 import { test, expect } from "bun:test"
 import { convertCircuitJsonToPcbSvg } from "circuit-to-svg"
 import { fp } from "../src/footprinter"
-import type { AnySoupElement, PCBSMTPad } from "circuit-json"
+import type { AnySoupElement, PcbSmtPad } from "circuit-json"
 
 test("bga footprint", () => {
   const soup = fp()
@@ -57,7 +57,7 @@ test("bga origin parameters", () => {
     "bga_2x2_bottom_left_origin",
   )
   const firstPadBl = soupBl.find(
-    (el): el is PCBSMTPad =>
+    (el): el is PcbSmtPad =>
       el.type === "pcb_smtpad" &&
       el.port_hints !== undefined &&
       el.port_hints[0] === "1",
@@ -73,7 +73,7 @@ test("bga origin parameters", () => {
     "bga_2x2_bottom_right_origin",
   )
   const firstPadBr = soupBr.find(
-    (el): el is PCBSMTPad =>
+    (el): el is PcbSmtPad =>
       el.type === "pcb_smtpad" &&
       el.port_hints !== undefined &&
       el.port_hints[0] === "1",
@@ -89,7 +89,7 @@ test("bga origin parameters", () => {
     "bga_2x2_top_right_origin",
   )
   const firstPadTr = soupTr.find(
-    (el): el is PCBSMTPad =>
+    (el): el is PcbSmtPad =>
       el.type === "pcb_smtpad" &&
       el.port_hints !== undefined &&
       el.port_hints[0] === "1",
@@ -105,7 +105,7 @@ test("bga origin parameters", () => {
     "bga_2x2_top_left_origin",
   )
   const firstPadTl = soupTl.find(
-    (el): el is PCBSMTPad =>
+    (el): el is PcbSmtPad =>
       el.type === "pcb_smtpad" &&
       el.port_hints !== undefined &&
       el.port_hints[0] === "1",
@@ -116,7 +116,7 @@ test("bga origin parameters", () => {
   // Verify that all pads are in the same physical positions regardless of origin
   const allPads = (soup: AnySoupElement[]) =>
     soup
-      .filter((el): el is PCBSMTPad => el.type === "pcb_smtpad")
+      .filter((el): el is PcbSmtPad => el.type === "pcb_smtpad")
       .sort((a, b) => (a.x === b.x ? a.y - b.y : a.x - b.x))
 
   const padsTl = allPads(soupTl)
@@ -140,7 +140,7 @@ test("bga circular pads", () => {
   const svgContent = convertCircuitJsonToPcbSvg(soup)
   expect(svgContent).toMatchSvgSnapshot(import.meta.path, "bga_circular_pads")
   const firstPad = soup.find(
-    (el): el is PCBSMTPad =>
+    (el): el is PcbSmtPad =>
       el.type === "pcb_smtpad" &&
       el.port_hints !== undefined &&
       el.port_hints[0] === "1",


### PR DESCRIPTION
This pull request standardizes the naming of the `PcbSmtPad` type across the codebase, replacing all instances of the old `PCBSMTPad` type. This improves consistency and aligns with the naming conventions used in the `circuit-json` package.

Type renaming and consistency:

* Replaced all imports and usages of `PCBSMTPad` with `PcbSmtPad` in `src/fn/bga.ts`, `src/helpers/pillpad.ts`, `src/helpers/rectpad.ts`, and `tests/bga.test.ts` to match the updated type name from `circuit-json`. [[1]](diffhunk://#diff-8e3c9b484b6ad0dd781af13a7049fe1fea45c081256a74bacab8998266e0c86fL1-R1) [[2]](diffhunk://#diff-8e3c9b484b6ad0dd781af13a7049fe1fea45c081256a74bacab8998266e0c86fL77-R77) [[3]](diffhunk://#diff-eb20c48f3ae5b47cff0191797c6b61da34eb71cd248c8ff03578c1a0dae29c13L1-R9) [[4]](diffhunk://#diff-0ffe39ee9eedd30cf9fc4b9a79011e5f087276b0d2951b5321bc43beebc630daL1-R8) [[5]](diffhunk://#diff-8139a71774cd1f517e0c611d2e88dd5fa2fe5246c5f0e58a56f8b2ffa022852dL4-R4) [[6]](diffhunk://#diff-8139a71774cd1f517e0c611d2e88dd5fa2fe5246c5f0e58a56f8b2ffa022852dL60-R60) [[7]](diffhunk://#diff-8139a71774cd1f517e0c611d2e88dd5fa2fe5246c5f0e58a56f8b2ffa022852dL76-R76) [[8]](diffhunk://#diff-8139a71774cd1f517e0c611d2e88dd5fa2fe5246c5f0e58a56f8b2ffa022852dL92-R92) [[9]](diffhunk://#diff-8139a71774cd1f517e0c611d2e88dd5fa2fe5246c5f0e58a56f8b2ffa022852dL108-R108) [[10]](diffhunk://#diff-8139a71774cd1f517e0c611d2e88dd5fa2fe5246c5f0e58a56f8b2ffa022852dL119-R119) [[11]](diffhunk://#diff-8139a71774cd1f517e0c611d2e88dd5fa2fe5246c5f0e58a56f8b2ffa022852dL143-R143)