### PR TITLE
add nopin option to omit pins rendering in mountedpcbmodule

### DIFF
--- a/src/fn/mountedpcbmodule.ts
+++ b/src/fn/mountedpcbmodule.ts
@@ -23,7 +23,11 @@ export const mountedpcbmodule_def = base_def
     id: length.default("1.0mm").describe("inner diameter"),
     od: length.default("1.5mm").describe("outer diameter"),
     male: z.boolean().optional().describe("the module uses male headers"),
-    nopin: z.boolean().optional().default(false).describe("omit pins rendering"),
+    nopin: z
+      .boolean()
+      .optional()
+      .default(false)
+      .describe("omit pins rendering"),
     female: z.boolean().optional().describe("the module uses female headers"),
     smd: z.boolean().optional().describe("surface mount device"),
     pinlabeltextalignleft: z.boolean().optional().default(false),


### PR DESCRIPTION
This pull request introduces an optional property to the `mountedpcbmodule_def` schema to provide more control over how pins are rendered in PCB modules.

Enhancement to rendering options:

* Added an optional `nopin` boolean property (defaulting to `false`) to the `mountedpcbmodule_def` schema in `src/fn/mountedpcbmodule.ts`, allowing users to omit pins from rendering when set to `true`.