### PR TITLE
fix: string parser now handles led and diode imperial sizes

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,10 +1,12 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
-  "assist": { "actions": { "source": { "organizeImports": "on" } } },
+  "$schema": "https://biomejs.dev/schemas/1.7.3/schema.json",
+  "organizeImports": {
+    "enabled": true
+  },
   "formatter": {
     "enabled": true,
     "indentStyle": "space",
-    "includes": ["**", "!**/node_modules", "!**/package.json", "!**/public"]
+    "ignore": ["node_modules", "package.json", "public"]
   },
   "javascript": {
     "formatter": {

--- a/biome.json
+++ b/biome.json
@@ -1,12 +1,10 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.7.3/schema.json",
-  "organizeImports": {
-    "enabled": true
-  },
+  "$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
+  "assist": { "actions": { "source": { "organizeImports": "on" } } },
   "formatter": {
     "enabled": true,
     "indentStyle": "space",
-    "ignore": ["node_modules", "package.json", "public"]
+    "includes": ["**", "!**/node_modules", "!**/package.json", "!**/public"]
   },
   "javascript": {
     "formatter": {

--- a/src/fn/melf.ts
+++ b/src/fn/melf.ts
@@ -79,10 +79,7 @@ export const melf = (
   }
 }
 
-export const getMelfCoords = (parameters: {
-  pn: number
-  p: number
-}) => {
+export const getMelfCoords = (parameters: { pn: number; p: number }) => {
   const { pn, p } = parameters
 
   if (pn === 1) {

--- a/src/fn/micromelf.ts
+++ b/src/fn/micromelf.ts
@@ -79,10 +79,7 @@ export const micromelf = (
   }
 }
 
-export const getMicroMelfCoords = (parameters: {
-  pn: number
-  p: number
-}) => {
+export const getMicroMelfCoords = (parameters: { pn: number; p: number }) => {
   const { pn, p } = parameters
 
   if (pn === 1) {

--- a/src/fn/minimelf.ts
+++ b/src/fn/minimelf.ts
@@ -79,10 +79,7 @@ export const minimelf = (
   }
 }
 
-export const getMiniMelfCoords = (parameters: {
-  pn: number
-  p: number
-}) => {
+export const getMiniMelfCoords = (parameters: { pn: number; p: number }) => {
   const { pn, p } = parameters
 
   return pn === 1 ? { x: -p / 2, y: 0 } : { x: p / 2, y: 0 }

--- a/src/fn/sma.ts
+++ b/src/fn/sma.ts
@@ -80,10 +80,7 @@ export const sma = (
 }
 
 // Get coordinates for sma pads
-export const getSmaCoords = (parameters: {
-  pn: number
-  p: number
-}) => {
+export const getSmaCoords = (parameters: { pn: number; p: number }) => {
   const { pn, p } = parameters
 
   if (pn === 1) {

--- a/src/fn/smb.ts
+++ b/src/fn/smb.ts
@@ -80,10 +80,7 @@ export const smb = (
 }
 
 // Get coordinates for smb pads
-export const getSmbCoords = (parameters: {
-  pn: number
-  p: number
-}) => {
+export const getSmbCoords = (parameters: { pn: number; p: number }) => {
   const { pn, p } = parameters
 
   if (pn === 1) {

--- a/src/fn/smbf.ts
+++ b/src/fn/smbf.ts
@@ -80,10 +80,7 @@ export const smbf = (
 }
 
 // Get coordinates for smbf pads
-export const getSmbfCoords = (parameters: {
-  pn: number
-  p: number
-}) => {
+export const getSmbfCoords = (parameters: { pn: number; p: number }) => {
   const { pn, p } = parameters
 
   if (pn === 1) {

--- a/src/fn/smc.ts
+++ b/src/fn/smc.ts
@@ -76,10 +76,7 @@ export const smc = (
 }
 
 // Get coordinates for smc pads
-export const getSmcCoords = (parameters: {
-  pn: number
-  p: number
-}) => {
+export const getSmcCoords = (parameters: { pn: number; p: number }) => {
   const { pn, p } = parameters
 
   if (pn === 1) {

--- a/src/fn/smf.ts
+++ b/src/fn/smf.ts
@@ -80,10 +80,7 @@ export const smf = (
 }
 
 // Get coordinates for smf pads
-export const getSmfCoords = (parameters: {
-  pn: number
-  p: number
-}) => {
+export const getSmfCoords = (parameters: { pn: number; p: number }) => {
   const { pn, p } = parameters
 
   if (pn === 1) {

--- a/src/fn/sod110.ts
+++ b/src/fn/sod110.ts
@@ -77,10 +77,7 @@ export const sod110 = (
   }
 }
 
-export const getSodCoords = (parameters: {
-  pn: number
-  p: number
-}) => {
+export const getSodCoords = (parameters: { pn: number; p: number }) => {
   const { pn, p } = parameters
 
   if (pn === 1) {

--- a/src/fn/sod123.ts
+++ b/src/fn/sod123.ts
@@ -46,10 +46,7 @@ export const sod123 = (
   }
 }
 
-export const getSodCoords = (parameters: {
-  pn: number
-  p: number
-}) => {
+export const getSodCoords = (parameters: { pn: number; p: number }) => {
   const { pn, p } = parameters
 
   if (pn === 1) {

--- a/src/fn/sod123f.ts
+++ b/src/fn/sod123f.ts
@@ -81,10 +81,7 @@ export const sod123f = (
 }
 
 // Get coordinates for SOD pads
-export const getSodCoords = (parameters: {
-  pn: number
-  p: number
-}) => {
+export const getSodCoords = (parameters: { pn: number; p: number }) => {
   const { pn, p } = parameters
 
   if (pn === 1) {

--- a/src/fn/sod123fl.ts
+++ b/src/fn/sod123fl.ts
@@ -81,10 +81,7 @@ export const sod123fl = (
 }
 
 // Get coordinates for SOD pads
-export const getSodCoords = (parameters: {
-  pn: number
-  p: number
-}) => {
+export const getSodCoords = (parameters: { pn: number; p: number }) => {
   const { pn, p } = parameters
 
   if (pn === 1) {

--- a/src/fn/sod123w.ts
+++ b/src/fn/sod123w.ts
@@ -81,10 +81,7 @@ export const sod123w = (
 }
 
 // Get coordinates for SOD pads
-export const getSodCoords = (parameters: {
-  pn: number
-  p: number
-}) => {
+export const getSodCoords = (parameters: { pn: number; p: number }) => {
   const { pn, p } = parameters
 
   if (pn === 1) {

--- a/src/fn/sod128.ts
+++ b/src/fn/sod128.ts
@@ -81,10 +81,7 @@ export const sod128 = (
 }
 
 // Get coordinates for SOD pads
-export const getSodCoords = (parameters: {
-  pn: number
-  p: number
-}) => {
+export const getSodCoords = (parameters: { pn: number; p: number }) => {
   const { pn, p } = parameters
 
   if (pn === 1) {

--- a/src/fn/sod323.ts
+++ b/src/fn/sod323.ts
@@ -80,10 +80,7 @@ export const sod323 = (
 }
 
 // Get coordinates for SOD pads
-export const getSodCoords = (parameters: {
-  pn: number
-  p: number
-}) => {
+export const getSodCoords = (parameters: { pn: number; p: number }) => {
   const { pn, p } = parameters
 
   if (pn === 1) {

--- a/src/fn/sod523.ts
+++ b/src/fn/sod523.ts
@@ -81,10 +81,7 @@ export const sod523 = (
 }
 
 // Get coordinates for SOD pads
-export const getSodCoords = (parameters: {
-  pn: number
-  p: number
-}) => {
+export const getSodCoords = (parameters: { pn: number; p: number }) => {
   const { pn, p } = parameters
 
   if (pn === 1) {

--- a/src/fn/sod723.ts
+++ b/src/fn/sod723.ts
@@ -80,10 +80,7 @@ export const sod723 = (
 }
 
 // Get coordinates for SOD pads
-export const getSodCoords = (parameters: {
-  pn: number
-  p: number
-}) => {
+export const getSodCoords = (parameters: { pn: number; p: number }) => {
   const { pn, p } = parameters
 
   if (pn === 1) {

--- a/src/fn/sod80.ts
+++ b/src/fn/sod80.ts
@@ -79,10 +79,7 @@ export const sod80 = (
   }
 }
 
-export const getsod80Coords = (parameters: {
-  pn: number
-  p: number
-}) => {
+export const getsod80Coords = (parameters: { pn: number; p: number }) => {
   const { pn, p } = parameters
 
   return pn === 1 ? { x: -p / 2, y: 0 } : { x: p / 2, y: 0 }

--- a/src/fn/sod882.ts
+++ b/src/fn/sod882.ts
@@ -81,10 +81,7 @@ export const sod882 = (
 }
 
 // Get coordinates for SOD pads
-export const getSodCoords = (parameters: {
-  pn: number
-  p: number
-}) => {
+export const getSodCoords = (parameters: { pn: number; p: number }) => {
   const { pn, p } = parameters
 
   if (pn === 1) {

--- a/src/fn/sod882d.ts
+++ b/src/fn/sod882d.ts
@@ -81,10 +81,7 @@ export const sod882d = (
 }
 
 // Get coordinates for SOD pads
-export const getSodCoords = (parameters: {
-  pn: number
-  p: number
-}) => {
+export const getSodCoords = (parameters: { pn: number; p: number }) => {
   const { pn, p } = parameters
 
   if (pn === 1) {

--- a/src/fn/sod923.ts
+++ b/src/fn/sod923.ts
@@ -105,10 +105,7 @@ export const sod923 = (
 }
 
 // Get coordinates for SOD pads
-export const getSodCoords = (parameters: {
-  pn: number
-  p: number
-}) => {
+export const getSodCoords = (parameters: { pn: number; p: number }) => {
   const { pn, p } = parameters
 
   if (pn === 1) {

--- a/src/footprinter.ts
+++ b/src/footprinter.ts
@@ -407,7 +407,12 @@ export const footprinter = (): Footprinter & {
             } else {
               target[prop] = true
               target.fn = prop
-              if (prop === "res" || prop === "cap" || prop === "led" || prop === "diode") {
+              if (
+                prop === "res" ||
+                prop === "cap" ||
+                prop === "led" ||
+                prop === "diode"
+              ) {
                 if (v) {
                   if (typeof v === "string" && v.includes("_metric")) {
                     target.metric = v.split("_metric")[0]

--- a/src/footprinter.ts
+++ b/src/footprinter.ts
@@ -407,7 +407,7 @@ export const footprinter = (): Footprinter & {
             } else {
               target[prop] = true
               target.fn = prop
-              if (prop === "res" || prop === "cap") {
+              if (prop === "res" || prop === "cap" || prop === "led" || prop === "diode") {
                 if (v) {
                   if (typeof v === "string" && v.includes("_metric")) {
                     target.metric = v.split("_metric")[0]


### PR DESCRIPTION
## Summary

Fix Issue #562 - String parser fails for led and diode with imperial sizes.

**Problem:** The string parser does not correctly handle imperial/metric size codes for `led` and `diode` footprints. While `res0402` and `cap0603` work correctly, `led0402` and `diode0603` throw an error.

**Root Cause:** In `src/footprinter.ts`, the proxy handler only recognizes `res` and `cap` as passive footprints that use imperial/metric sizing.


**Solution:** Added `led` and `diode` to the list of passive footprints that use imperial sizing.


```typescript
// Before
if (prop === "res" || prop === "cap") {

// After
if (prop === "res" || prop === "cap" || prop === "led" || prop === "diode") {
```

## Testing

- `led0402` now correctly parses as `{ fn: "led", imperial: "0402" }`
- `diode0603` now correctly parses as `{ fn: "diode", imperial: "0603" }`