### PR TITLE
fix: parse imperial/metric sizes for led and diode string footprints

### DIFF
--- a/src/footprinter.ts
+++ b/src/footprinter.ts
@@ -407,7 +407,7 @@ export const footprinter = (): Footprinter & {
             } else {
               target[prop] = true
               target.fn = prop
-              if (prop === "res" || prop === "cap") {
+              if (prop === "res" || prop === "cap" || prop === "diode" || prop === "led") {
                 if (v) {
                   if (typeof v === "string" && v.includes("_metric")) {
                     target.metric = v.split("_metric")[0]

--- a/src/footprinter.ts
+++ b/src/footprinter.ts
@@ -407,7 +407,12 @@ export const footprinter = (): Footprinter & {
             } else {
               target[prop] = true
               target.fn = prop
-              if (prop === "res" || prop === "cap" || prop === "diode" || prop === "led") {
+              if (
+                prop === "res" ||
+                prop === "cap" ||
+                prop === "diode" ||
+                prop === "led"
+              ) {
                 if (v) {
                   if (typeof v === "string" && v.includes("_metric")) {
                     target.metric = v.split("_metric")[0]


### PR DESCRIPTION
## Summary

Fixes #562 - String parser failed for led and diode with imperial sizes (e.g., led0402, diode0603).

**Root Cause:** In `src/footprinter.ts`, the proxy handler only recognized `res` and `cap` as passive footprints that use imperial/metric sizing. When parsing `led0402`, it was treated as `{ fn: "led", num_pins: 402 }` instead of `{ fn: "led", imperial: "0402" }`.

**Fix:** Extended the condition to also include `diode` and `led`:

```typescript
// Before
if (prop === "res" || prop === "cap") {

// After  
if (prop === "res" || prop === "cap" || prop === "diode" || prop === "led") {
```

## Test plan

- [x] `fp.string("led0402").json()` now correctly returns `{ fn: "led", imperial: "0402" }`
- [x] `fp.string("diode0603").json()` now correctly returns `{ fn: "diode", imperial: "0603" }`
- [x] All 412 existing tests pass

Closes #562