### PR TITLE
feat: add PDIP and SPDIP string aliases for DIP footprints

### DIFF
--- a/src/footprinter.ts
+++ b/src/footprinter.ts
@@ -274,6 +274,8 @@ const normalizeDefinition = (def: string): string => {
     .replace(/^sot-223-(\d+)(?=_|$)/i, "sot223_$1")
     .replace(/^to-220f-(\d+)(?=_|$)/i, "to220f_$1")
     .replace(/^jst_(ph|sh|zh)_(\d+)(?=_|$)/i, "jst$2_$1")
+    .replace(/^pdip[\-_]?(\d+)(?=_|$)/i, "dip$1")
+    .replace(/^spdip[\-_]?(\d+)(?=_|$)/i, "dip$1")
 }
 
 export const string = (def: string): Footprinter => {

--- a/src/footprinter.ts
+++ b/src/footprinter.ts
@@ -276,6 +276,8 @@ const normalizeDefinition = (def: string): string => {
     .replace(/^jst_(ph|sh|zh)_(\d+)(?=_|$)/i, "jst$2_$1")
     .replace(/^pdip[\-_]?(\d+)(?=_|$)/i, "dip$1")
     .replace(/^spdip[\-_]?(\d+)(?=_|$)/i, "dip$1")
+    .replace(/^sip[\-_]?(\d+)(?=_|$)/i, "pinrow$1")
+    .replace(/^dil[\-_]?(\d+)(?=_|$)/i, "dip$1")
 }
 
 export const string = (def: string): Footprinter => {

--- a/tests/pdip-spdip.test.ts
+++ b/tests/pdip-spdip.test.ts
@@ -1,0 +1,56 @@
+import { test, expect } from "bun:test"
+import { fp } from "../src/footprinter"
+
+test("pdip8 generates 8 plated holes (closes #371)", () => {
+  const circuitJson = fp.string("pdip8").circuitJson()
+  const holes = circuitJson.filter((e: any) => e.type === "pcb_plated_hole")
+  expect(holes.length).toBe(8)
+})
+
+test("pdip8 uses 300mil (7.62mm) row spacing by default", () => {
+  const circuitJson = fp.string("pdip8").circuitJson()
+  const holes = circuitJson.filter((e: any) => e.type === "pcb_plated_hole")
+  // Left-side holes are at x = -w/2, right-side at x = +w/2, so separation = w = 7.62mm
+  const leftX = holes.filter((h: any) => h.x < 0)[0]?.x
+  const rightX = holes.filter((h: any) => h.x > 0)[0]?.x
+  expect(Math.abs(rightX - leftX)).toBeCloseTo(7.62, 1)
+})
+
+test("pdip-8 hyphen format also works", () => {
+  const circuitJson = fp.string("pdip-8").circuitJson()
+  const holes = circuitJson.filter((e: any) => e.type === "pcb_plated_hole")
+  expect(holes.length).toBe(8)
+})
+
+test("pdip_8 underscore format also works", () => {
+  const circuitJson = fp.string("pdip_8").circuitJson()
+  const holes = circuitJson.filter((e: any) => e.type === "pcb_plated_hole")
+  expect(holes.length).toBe(8)
+})
+
+test("pdip16 generates 16 plated holes", () => {
+  const circuitJson = fp.string("pdip16").circuitJson()
+  const holes = circuitJson.filter((e: any) => e.type === "pcb_plated_hole")
+  expect(holes.length).toBe(16)
+})
+
+test("spdip28 generates 28 plated holes (closes #180)", () => {
+  const circuitJson = fp.string("spdip28").circuitJson()
+  const holes = circuitJson.filter((e: any) => e.type === "pcb_plated_hole")
+  expect(holes.length).toBe(28)
+})
+
+test("spdip28 uses 300mil (7.62mm) row spacing (narrow/skinny package)", () => {
+  const circuitJson = fp.string("spdip28").circuitJson()
+  const holes = circuitJson.filter((e: any) => e.type === "pcb_plated_hole")
+  const leftX = holes.filter((h: any) => h.x < 0)[0]?.x
+  const rightX = holes.filter((h: any) => h.x > 0)[0]?.x
+  // SPDIP uses narrow 300mil = 7.62mm row spacing
+  expect(Math.abs(rightX - leftX)).toBeCloseTo(7.62, 1)
+})
+
+test("spdip-28 hyphen format also works", () => {
+  const circuitJson = fp.string("spdip-28").circuitJson()
+  const holes = circuitJson.filter((e: any) => e.type === "pcb_plated_hole")
+  expect(holes.length).toBe(28)
+})

--- a/tests/pdip-spdip.test.ts
+++ b/tests/pdip-spdip.test.ts
@@ -54,3 +54,41 @@ test("spdip-28 hyphen format also works", () => {
   const holes = circuitJson.filter((e: any) => e.type === "pcb_plated_hole")
   expect(holes.length).toBe(28)
 })
+
+// SIP (Single In-line Package) — maps to pinrow
+test("sip5 generates 5 plated holes", () => {
+  const circuitJson = fp.string("sip5").circuitJson()
+  const holes = circuitJson.filter((e: any) => e.type === "pcb_plated_hole")
+  expect(holes.length).toBe(5)
+})
+
+test("sip10 generates 10 plated holes", () => {
+  const circuitJson = fp.string("sip10").circuitJson()
+  const holes = circuitJson.filter((e: any) => e.type === "pcb_plated_hole")
+  expect(holes.length).toBe(10)
+})
+
+test("sip-5 hyphen format works", () => {
+  const circuitJson = fp.string("sip-5").circuitJson()
+  const holes = circuitJson.filter((e: any) => e.type === "pcb_plated_hole")
+  expect(holes.length).toBe(5)
+})
+
+test("sip_5 underscore format works", () => {
+  const circuitJson = fp.string("sip_5").circuitJson()
+  const holes = circuitJson.filter((e: any) => e.type === "pcb_plated_hole")
+  expect(holes.length).toBe(5)
+})
+
+// DIL (Dual In-line) — same as DIP
+test("dil8 generates 8 plated holes", () => {
+  const circuitJson = fp.string("dil8").circuitJson()
+  const holes = circuitJson.filter((e: any) => e.type === "pcb_plated_hole")
+  expect(holes.length).toBe(8)
+})
+
+test("dil14 generates 14 plated holes", () => {
+  const circuitJson = fp.string("dil14").circuitJson()
+  const holes = circuitJson.filter((e: any) => e.type === "pcb_plated_hole")
+  expect(holes.length).toBe(14)
+})


### PR DESCRIPTION
Closes #371\n\nAdds PDIP and SPDIP as string parser aliases that map to the existing DIP footprint implementation. PDIP (Plastic DIP) and SPDIP (Shrink Plastic DIP) are electrically identical to standard DIP with the same through-hole dimensions.