### PR TITLE
fix: support imperial/metric size codes for led and diode string footprints

### DIFF
--- a/src/footprinter.ts
+++ b/src/footprinter.ts
@@ -407,7 +407,12 @@ export const footprinter = (): Footprinter & {
             } else {
               target[prop] = true
               target.fn = prop
-              if (prop === "res" || prop === "cap") {
+              if (
+                prop === "res" ||
+                prop === "cap" ||
+                prop === "led" ||
+                prop === "diode"
+              ) {
                 if (v) {
                   if (typeof v === "string" && v.includes("_metric")) {
                     target.metric = v.split("_metric")[0]


### PR DESCRIPTION
## Summary

The string parser only handled imperial/metric size codes for `res` and `cap` footprints, but `led` and `diode` footprints use the same `passive()` underlying function and should support the same string syntax.

## Root Cause

In `src/footprinter.ts`, the proxy handler only checked for `res` and `cap` when deciding to set `imperial`:

```typescript
if (prop === "res" || prop === "cap") {
  target.imperial = v // e.g., res0402, cap0603
} else {
  target.num_pins = Number.parseFloat(v) // led0402 incorrectly parsed as led with 402 pins
}
```

## Fix

Added `led` and `diode` to the condition so all four passive types support the string syntax.

## Testing

```typescript
fp.string("led0402").circuitJson()    // ✓ now works
fp.string("led0603").circuitJson()    // ✓ now works  
fp.string("diode0402").circuitJson()  // ✓ now works
fp.string("diode0805").circuitJson()  // ✓ now works
```

Fixes #562