### PR TITLE
fix(pinrow): pitch-aware id/od defaults so 1.27 mm headers don't overlap

### DIFF
--- a/src/fn/pinrow.ts
+++ b/src/fn/pinrow.ts
@@ -25,8 +25,11 @@ export const pinrow_def = base_def
       .default(1)
       .describe("number of rows"),
     p: length.default("0.1in").describe("pitch"),
-    id: length.default("1.0mm").describe("inner diameter"),
-    od: length.default("1.5mm").describe("outer diameter"),
+    // id/od defaults are computed from pitch in the transform below so
+    // small-pitch headers (e.g. p=1.27mm for ARM Cortex Debug) don't
+    // produce overlapping holes. Explicit user values are honoured.
+    id: length.optional().describe("inner diameter (drill)"),
+    od: length.optional().describe("outer diameter (annular pad)"),
     male: z.boolean().optional().describe("for male pin headers"),
     female: z.boolean().optional().describe("for female pin headers"),
     smd: z.boolean().optional().describe("surface mount device"),
@@ -67,8 +70,20 @@ export const pinrow_def = base_def
   })
   .transform((data) => {
     const pinlabelAnchorSide = determinePinlabelAnchorSide(data)
+    // Pitch-aware id/od defaults. At the standard 2.54 mm pitch this
+    // gives id=1.0 mm / od=1.5 mm (the previous hardcoded defaults);
+    // at smaller pitches the values scale down so the pads don't
+    // overlap.
+    //   od_default = min(1.5 mm, pitch − 0.27 mm)
+    //                → ≥ 0.27 mm copper-to-copper between adjacent pads
+    //   id_default = min(1.0 mm, od_default − 0.4 mm)
+    //                → ~0.5 mm annular ring (>= IPC class 2 minimum)
+    const od = data.od ?? Math.min(1.5, data.p - 0.27)
+    const id = data.id ?? Math.min(1.0, od - 0.4)
     return {
       ...data,
+      id,
+      od,
       pinlabelAnchorSide,
       male: data.male ?? !data.female,
       female: data.female ?? false,

--- a/tests/pinrow_pitch_aware_defaults.test.ts
+++ b/tests/pinrow_pitch_aware_defaults.test.ts
@@ -1,0 +1,35 @@
+import { test, expect } from "bun:test"
+import { fp } from "../src/footprinter"
+
+// Regression: at small pitches (e.g. 1.27 mm for ARM Cortex Debug
+// headers), the previous hardcoded defaults id=1.0 mm / od=1.5 mm
+// produced overlapping plated-hole pads (1.5 mm OD on 1.27 mm pitch =
+// −0.23 mm copper-to-copper clearance — fab-breaking).
+//
+// New behaviour: id/od defaults are derived from pitch when the user
+// doesn't specify them. The 2.54 mm default pitch still yields the
+// historical id=1.0 mm / od=1.5 mm.
+
+test("default pitch (2.54 mm) keeps id=1.0 / od=1.5 (backward compat)", () => {
+  const json = fp.string("pinrow5").json() as any
+  expect(json.p).toBe(2.54)
+  expect(json.od).toBe(1.5)
+  expect(json.id).toBe(1)
+})
+
+test("p=1.27mm default od/id scale down so pads do not overlap", () => {
+  const json = fp.string("pinrow10_p1.27mm_rows2").json() as any
+  expect(json.p).toBe(1.27)
+  // od must be ≤ pitch − some clearance
+  expect(json.od).toBeLessThanOrEqual(json.p - 0.2)
+  // id must leave a usable annular ring
+  expect(json.id).toBeLessThan(json.od)
+  expect(json.od - json.id).toBeGreaterThanOrEqual(0.3)
+})
+
+test("explicit od/id override defaults at any pitch", () => {
+  const json = fp.string("pinrow5_p1.27mm_id0.6mm_od1.0mm").json() as any
+  expect(json.p).toBe(1.27)
+  expect(json.id).toBe(0.6)
+  expect(json.od).toBe(1)
+})


### PR DESCRIPTION
## Summary

`pinrow`'s default `id="1.0mm"` / `od="1.5mm"` are tuned for the 0.1in (2.54 mm) pitch and produce **fab-breaking overlap** at smaller pitches. Concretely, at the standard ARM Cortex Debug pitch of 1.27 mm with default `od=1.5mm`, adjacent plated holes overlap by **0.23 mm**.

## Fix

Make `id` and `od` optional in the schema; compute defaults from pitch in the transform:

```ts
// Pitch-aware id/od defaults. Backward-compatible at 2.54 mm pitch.
const od = data.od ?? Math.min(1.5, data.p - 0.27)
const id = data.id ?? Math.min(1.0, od - 0.4)
```

| Pitch | New default `od` | New default `id` | Notes |
|---|---|---|---|
| 2.54 mm (0.1") | 1.5 mm | 1.0 mm | **Unchanged** — backward compatible |
| 2.0 mm | 1.5 mm | 1.0 mm | Still fits with 0.5 mm clearance |
| 1.27 mm (0.05", Cortex Debug) | 1.0 mm | 0.6 mm | Matches generic JLCPCB 1.27 mm headers (e.g. ZX_PZ1_27_2_5PZZ) |
| explicit user values | honoured | honoured | No override of explicit `id`/`od` at any pitch |

## Test plan

- [x] All 25 existing pinrow tests pass unchanged (default-pitch behaviour preserved)
- [x] New `tests/pinrow_pitch_aware_defaults.test.ts` adds:
   - default pitch backward-compat (`p=2.54mm` → `id=1.0`/`od=1.5`)
   - small-pitch defaults scale down (`p=1.27mm` → `od ≤ p − 0.2`, annular ring ≥ 0.3 mm)
   - explicit `id`/`od` override defaults at any pitch
- [x] `bun test`: 415 pass (one flaky timeout in `slop1.test.ts` unrelated to this change, passed on rerun)
- [x] `bun run format`: clean

## Repro

```tsx
<board width="22mm" height="20mm">
  <pinheader name="J1" pinCount={10} pitch="1.27mm" doubleRow />
</board>
```

Before this PR, `tsci build` reports the resulting plated holes as 1.5 mm OD and they overlap. With this PR, defaults become 1.0 mm OD / 0.6 mm drill — same as the typical JLCPCB Cortex Debug header SKU.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
