### PR TITLE
Add PDIP-8 footprint alias

### DIFF
--- a/src/footprinter.ts
+++ b/src/footprinter.ts
@@ -271,6 +271,7 @@ const normalizeDefinition = (def: string): string => {
   return def
     .trim()
     .replace(/^pinheader(?=[\d_]|$)/i, "pinrow")
+    .replace(/^pdip-?(\d+)(?=_|$)/i, "dip$1")
     .replace(/^sot23-(\d+)(?=_|$)/i, "sot23_$1")
     .replace(/^sot-223-(\d+)(?=_|$)/i, "sot223_$1")
     .replace(/^to-220f-(\d+)(?=_|$)/i, "to220f_$1")

--- a/tests/dip.test.ts
+++ b/tests/dip.test.ts
@@ -1,7 +1,7 @@
-import { test, expect } from "bun:test"
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
 import { convertCircuitJsonToPcbSvg } from "circuit-to-svg"
 import { fp } from "../src/footprinter"
-import type { AnyCircuitElement } from "circuit-json"
 
 test("dip footprint", () => {
   const circuitJson = fp().dip(4).w(4).p(2).circuitJson()
@@ -20,6 +20,16 @@ test("DIP16 string resolves using lowercase function", () => {
   const lowercaseJson = fp.string("dip16").json()
   expect(uppercaseJson).toEqual(lowercaseJson)
 })
+
+test("PDIP-8 aliases resolve to dip8", () => {
+  const pdipJson = fp.string("PDIP-8").json()
+  const compactPdipJson = fp.string("pdip8").json()
+  const dipJson = fp.string("dip8").json()
+
+  expect(pdipJson).toEqual(dipJson)
+  expect(compactPdipJson).toEqual(dipJson)
+})
+
 test("dip16 with nosquareplating", () => {
   const circuitJson = fp
     .string("dip16_nosquareplating")
@@ -81,7 +91,7 @@ test("dip4", () => {
 
 test("dip8_p1.27mm", () => {
   const circuitJson = fp.string("dip8_p1.27mm").circuitJson()
-  let svgContent = convertCircuitJsonToPcbSvg(circuitJson)
+  const svgContent = convertCircuitJsonToPcbSvg(circuitJson)
   expect(svgContent).toMatchSvgSnapshot(import.meta.path, "dip8_p1.27mm")
 })
 


### PR DESCRIPTION
/claim #371

Adds PDIP string normalization for the existing DIP footprint generator so common package names such as `PDIP-8`, `pdip8`, and parameterized forms like `pdip8_w7.62mm` resolve through the same implementation as `dip8`.

This keeps the footprint geometry in one place instead of duplicating the DIP generator for the plastic DIP naming variant.

Verification run locally:

- `npm exec -- biome check src/footprinter.ts tests/dip.test.ts`
- `npm run build`
- direct Node check against the built package confirming `PDIP-8` and `pdip8` produce the same JSON as `dip8`
- `git diff --check`

Notes:

- The repo expects `bun test`, but `bun` is not installed in this environment, so I could not run the Bun test suite directly.
- `npm exec -- tsc --noEmit` currently reports unrelated pre-existing type errors in several test files involving circuit-json union types; `npm run build` succeeds for the package source and declarations.