### PR TITLE
Add SPDIP-28 footprint alias

### DIFF
--- a/src/footprinter.ts
+++ b/src/footprinter.ts
@@ -271,6 +271,7 @@ const normalizeDefinition = (def: string): string => {
   return def
     .trim()
     .replace(/^pinheader(?=[\d_]|$)/i, "pinrow")
+    .replace(/^spdip-?(\d+)(?=_|$)/i, "dip$1")
     .replace(/^sot23-(\d+)(?=_|$)/i, "sot23_$1")
     .replace(/^sot-223-(\d+)(?=_|$)/i, "sot223_$1")
     .replace(/^to-220f-(\d+)(?=_|$)/i, "to220f_$1")

--- a/tests/dip.test.ts
+++ b/tests/dip.test.ts
@@ -1,7 +1,7 @@
-import { test, expect } from "bun:test"
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
 import { convertCircuitJsonToPcbSvg } from "circuit-to-svg"
 import { fp } from "../src/footprinter"
-import type { AnyCircuitElement } from "circuit-json"
 
 test("dip footprint", () => {
   const circuitJson = fp().dip(4).w(4).p(2).circuitJson()
@@ -20,6 +20,16 @@ test("DIP16 string resolves using lowercase function", () => {
   const lowercaseJson = fp.string("dip16").json()
   expect(uppercaseJson).toEqual(lowercaseJson)
 })
+
+test("SPDIP-28 aliases resolve to dip28", () => {
+  const spdipJson = fp.string("SPDIP-28").json()
+  const compactSpdipJson = fp.string("spdip28").json()
+  const dipJson = fp.string("dip28").json()
+
+  expect(spdipJson).toEqual(dipJson)
+  expect(compactSpdipJson).toEqual(dipJson)
+})
+
 test("dip16 with nosquareplating", () => {
   const circuitJson = fp
     .string("dip16_nosquareplating")
@@ -81,7 +91,7 @@ test("dip4", () => {
 
 test("dip8_p1.27mm", () => {
   const circuitJson = fp.string("dip8_p1.27mm").circuitJson()
-  let svgContent = convertCircuitJsonToPcbSvg(circuitJson)
+  const svgContent = convertCircuitJsonToPcbSvg(circuitJson)
   expect(svgContent).toMatchSvgSnapshot(import.meta.path, "dip8_p1.27mm")
 })
 


### PR DESCRIPTION
/claim #180

Adds SPDIP string normalization for the existing DIP footprint generator so common package names such as `SPDIP-28`, `spdip28`, and parameterized forms like `spdip28_w7.62mm` resolve through the same implementation as `dip28`.

This keeps skinny/plastic DIP naming variants on the same DIP geometry path instead of adding a duplicated footprint generator.

Verification run locally:

- `npm exec -- biome check src/footprinter.ts tests/dip.test.ts`
- `npm run build`
- direct Node check against the built package confirming `SPDIP-28` and `spdip28` produce the same JSON as `dip28`
- `git diff --check`

Notes:

- The repo expects `bun test`, but `bun` is not installed in this environment, so I could not run the Bun test suite directly.