### PR TITLE
Implement SPDIP footprint

### DIFF
--- a/src/fn/index.ts
+++ b/src/fn/index.ts
@@ -1,4 +1,5 @@
 export { dip } from "./dip"
+export { spdip } from "./spdip"
 export { diode } from "./diode"
 export { cap } from "./cap"
 export { led } from "./led"

--- a/src/fn/spdip.ts
+++ b/src/fn/spdip.ts
@@ -1,0 +1,14 @@
+import { dip } from "./dip"
+
+export const spdip = (rawParams: {
+  spdip: true
+  num_pins: number
+  p?: number
+  id?: string | number
+  od?: string | number
+}) =>
+  dip({
+    ...rawParams,
+    dip: true,
+    w: 15.24,
+  })

--- a/src/footprinter.ts
+++ b/src/footprinter.ts
@@ -40,6 +40,7 @@ export type Footprinter = {
   dip: (
     num_pins?: number,
   ) => FootprinterParamsBuilder<"w" | "p" | "id" | "od" | "wide" | "narrow">
+  spdip: (num_pins?: number) => FootprinterParamsBuilder<"p" | "id" | "od">
   cap: () => FootprinterParamsBuilder<CommonPassiveOptionKey>
   res: () => FootprinterParamsBuilder<CommonPassiveOptionKey>
   diode: () => FootprinterParamsBuilder<CommonPassiveOptionKey>

--- a/tests/spdip.test.ts
+++ b/tests/spdip.test.ts
@@ -1,0 +1,23 @@
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { fp } from "../src/footprinter"
+
+test("spdip28 uses 0.6in row spacing", () => {
+  const json = fp.string("spdip28").json()
+
+  expect(json).toMatchObject({
+    fn: "spdip",
+    num_pins: 28,
+    p: 2.54,
+    w: 15.24,
+  })
+})
+
+test("spdip28 creates 28 plated holes", () => {
+  const circuitJson = fp.string("spdip28").circuitJson() as AnyCircuitElement[]
+  const platedHoles = circuitJson.filter(
+    (elm) => elm.type === "pcb_plated_hole",
+  )
+
+  expect(platedHoles).toHaveLength(28)
+})


### PR DESCRIPTION
Fixes #180.

Changes:
- Adds an `spdip` footprint function that reuses the DIP generator with 0.6in / 15.24mm row spacing.
- Exposes `spdip` through the footprint function index and TypeScript builder type.
- Adds coverage for `spdip28` parameters and generated plated holes.

Verification:
- `npm run build` -> passed
- `npx bun test tests/spdip.test.ts` -> 2 passed
- `npx biome check src/fn/spdip.ts tests/spdip.test.ts` -> passed