### PR TITLE
Add PDIP footprint alias

### DIFF
--- a/src/footprinter.ts
+++ b/src/footprinter.ts
@@ -271,6 +271,7 @@ const normalizeDefinition = (def: string): string => {
   return def
     .trim()
     .replace(/^pinheader(?=[\d_]|$)/i, "pinrow")
+    .replace(/^pdip-?(\d+)(?=_|$)/i, "dip_$1")
     .replace(/^sot23-(\d+)(?=_|$)/i, "sot23_$1")
     .replace(/^sot-223-(\d+)(?=_|$)/i, "sot223_$1")
     .replace(/^to-220f-(\d+)(?=_|$)/i, "to220f_$1")

--- a/tests/pdip.test.ts
+++ b/tests/pdip.test.ts
@@ -1,0 +1,17 @@
+import { test, expect } from "bun:test"
+import { convertCircuitJsonToPcbSvg } from "circuit-to-svg"
+import { fp } from "../src/footprinter"
+
+test("PDIP-8 aliases to DIP-8", () => {
+  const pdipSvg = convertCircuitJsonToPcbSvg(fp.string("PDIP-8").circuitJson())
+  const dipSvg = convertCircuitJsonToPcbSvg(fp.string("dip_8").circuitJson())
+
+  expect(pdipSvg).toEqual(dipSvg)
+})
+
+test("pdip8 compact form aliases to DIP-8", () => {
+  const pdipSvg = convertCircuitJsonToPcbSvg(fp.string("pdip8").circuitJson())
+  const dipSvg = convertCircuitJsonToPcbSvg(fp.string("dip_8").circuitJson())
+
+  expect(pdipSvg).toEqual(dipSvg)
+})


### PR DESCRIPTION
Fixes #371.

Adds support for PDIP package strings by normalizing PDIP-8/pdip8 to the existing DIP footprint implementation. PDIP is the plastic DIP package family, so this keeps output consistent with the existing DIP geometry instead of duplicating footprint code.

Verification:
- npx bun test tests/pdip.test.ts
- npm run build