### PR TITLE
test(jst): assert jst_ph_4 has four pin plated holes (#495)

### DIFF
--- a/tests/jst.test.ts
+++ b/tests/jst.test.ts
@@ -49,6 +49,16 @@ test("jst_ph_4 (pretransform)", () => {
   expect(svgContent).toMatchSvgSnapshot(import.meta.path + "jst_ph_4")
 })
 
+test("jst_ph_4 has four pin plated holes (regression #495)", () => {
+  const circuitJson = fp.string("jst_ph_4").circuitJson()
+  const pinHoles = circuitJson.filter(
+    (e) =>
+      e.type === "pcb_plated_hole" &&
+      e.shape === "circular_hole_with_rect_pad",
+  )
+  expect(pinHoles.length).toBe(4)
+})
+
 test("jst_sh_6 (pretransform)", () => {
   const circuitJson = fp.string("jst_sh_6").circuitJson()
   const params = fp.string("jst_sh_6").json() as any


### PR DESCRIPTION
## Summary
Issue tscircuit/footprinter#495 mô tả \jst_ph_4\ chỉ ra 2 pad; trên \main\ hiện tại footprint đã parse đúng số chân (qua pretransform \jst_ph_N\ → \jstN_ph\) và \generatePads\ cho PH tạo \
umPins\ lỗ plated.

PR này thêm **assertion** để không tái phát: đếm đúng **4** \pcb_plated_hole\ dạng \circular_hole_with_rect_pad\ cho \jst_ph_4\.

## Test plan
- [x] \un test tests/jst.test.ts\

Closes #495