### PR TITLE
Add SPDIP-28 string alias

### DIFF
--- a/src/footprinter.ts
+++ b/src/footprinter.ts
@@ -271,6 +271,7 @@ const normalizeDefinition = (def: string): string => {
   return def
     .trim()
     .replace(/^pinheader(?=[\d_]|$)/i, "pinrow")
+    .replace(/^spdip-?(\d+)(?=_|$)/i, "dip$1")
     .replace(/^sot23-(\d+)(?=_|$)/i, "sot23_$1")
     .replace(/^sot-223-(\d+)(?=_|$)/i, "sot223_$1")
     .replace(/^to-220f-(\d+)(?=_|$)/i, "to220f_$1")

--- a/tests/dip.test.ts
+++ b/tests/dip.test.ts
@@ -20,6 +20,14 @@ test("DIP16 string resolves using lowercase function", () => {
   const lowercaseJson = fp.string("dip16").json()
   expect(uppercaseJson).toEqual(lowercaseJson)
 })
+
+test("SPDIP-28 string resolves to DIP-28 geometry", () => {
+  const spdipJson = fp.string("SPDIP-28").json()
+  const dipJson = fp.string("dip28").json()
+
+  expect(spdipJson).toEqual(dipJson)
+})
+
 test("dip16 with nosquareplating", () => {
   const circuitJson = fp
     .string("dip16_nosquareplating")


### PR DESCRIPTION
## Summary
- normalize SPDIP-28/SPDIP28 footprint strings to existing DIP-28 geometry
- add coverage proving SPDIP-28 resolves the same as dip28

Fixes #180

## Test
- npx --yes bun test tests\\dip.test.ts