### PR TITLE
Improve missing footprint function errors

### DIFF
--- a/src/footprinter.ts
+++ b/src/footprinter.ts
@@ -337,6 +337,17 @@ export const getFootprintNamesByType = (): {
   }
 }
 
+const createFootprintFunctionNotFoundError = (target: any) => {
+  const fn = target.fn
+  const source = target.string ? `, from string "${target.string}"` : ""
+  const received =
+    typeof fn === "string" && fn.length > 0 ? `"${fn}"` : "no function"
+
+  return new Error(
+    `Function not found for footprinter ${received}${source}. Specify a valid function like .dip, .lr, .p, etc.`,
+  )
+}
+
 export const footprinter = (): Footprinter & {
   string: typeof string
   getFootprintNames: string[]
@@ -363,27 +374,16 @@ export const footprinter = (): Footprinter & {
           }
 
           if (!FOOTPRINT_FN[target.fn]) {
-            throw new Error(
-              `Invalid footprint function, got "${target.fn}"${
-                target.string ? `, from string "${target.string}"` : ""
-              }`,
-            )
+            throw createFootprintFunctionNotFoundError(target)
           }
 
           return () => {
-            // TODO improve error
-            throw new Error(
-              `No function found for footprinter, make sure to specify .dip, .lr, .p, etc. Got "${prop}"`,
-            )
+            throw createFootprintFunctionNotFoundError(target)
           }
         }
         if (prop === "json") {
           if (!FOOTPRINT_FN[target.fn]) {
-            throw new Error(
-              `Invalid footprint function, got "${target.fn}"${
-                target.string ? `, from string "${target.string}"` : ""
-              }`,
-            )
+            throw createFootprintFunctionNotFoundError(target)
           }
           return () => FOOTPRINT_FN[target.fn](target).parameters
         }

--- a/tests/fp-string-error.test.ts
+++ b/tests/fp-string-error.test.ts
@@ -1,8 +1,14 @@
-import { test, expect } from "bun:test"
+import { expect, test } from "bun:test"
 import { fp } from "src/footprinter"
 
 test("fp.string error", () => {
   expect(() => fp.string("nonexistentfn4_p3").circuitJson()).toThrow(
-    'Invalid footprint function, got "nonexistentfn", from string "nonexistentfn4_p3"',
+    'Function not found for footprinter "nonexistentfn", from string "nonexistentfn4_p3". Specify a valid function like .dip, .lr, .p, etc.',
+  )
+})
+
+test("fp builder error when no footprint function is selected", () => {
+  expect(() => fp().soup()).toThrow(
+    "Function not found for footprinter no function. Specify a valid function like .dip, .lr, .p, etc.",
   )
 })

--- a/tests/vssop.test.ts
+++ b/tests/vssop.test.ts
@@ -123,7 +123,8 @@ test("invalid_vssop6", () => {
   } catch (error) {
     const e = error as Error
     expect(e).toBeInstanceOf(Error)
-    expect(e.message).toContain("Invalid footprint function")
+    expect(e.message).toContain("Function not found for footprinter")
+    expect(e.message).toContain('"invalid"')
   }
 })
 


### PR DESCRIPTION
## Summary
- replace the generic invalid footprint-function error with an explicit “Function not found for footprinter …” message
- include the missing function name and original footprint string when available
- add regression coverage for invalid string footprints and builder calls with no selected function

Closes #46

## Verification
- bun test tests/fp-string-error.test.ts tests/vssop.test.ts
- bun test
- bun run build
- git diff --check

AI-assisted with Codex; I reviewed the diff and local verification before submission.