### PR TITLE
Add PDIP-8 footprint alias

### DIFF
--- a/src/footprinter.ts
+++ b/src/footprinter.ts
@@ -271,6 +271,7 @@ const normalizeDefinition = (def: string): string => {
   return def
     .trim()
     .replace(/^pinheader(?=[\d_]|$)/i, "pinrow")
+    .replace(/^pdip-?(\d+)(?=_|$)/i, "dip$1")
     .replace(/^sot23-(\d+)(?=_|$)/i, "sot23_$1")
     .replace(/^sot-223-(\d+)(?=_|$)/i, "sot223_$1")
     .replace(/^to-220f-(\d+)(?=_|$)/i, "to220f_$1")

--- a/tests/dip.test.ts
+++ b/tests/dip.test.ts
@@ -20,6 +20,19 @@ test("DIP16 string resolves using lowercase function", () => {
   const lowercaseJson = fp.string("dip16").json()
   expect(uppercaseJson).toEqual(lowercaseJson)
 })
+
+test("PDIP-8 string resolves to DIP8", () => {
+  const pdipJson = fp.string("PDIP-8").json()
+  const dipJson = fp.string("dip8").json()
+  expect(pdipJson).toEqual(dipJson)
+})
+
+test("pdip8 string resolves to DIP8", () => {
+  const pdipJson = fp.string("pdip8").json()
+  const dipJson = fp.string("dip8").json()
+  expect(pdipJson).toEqual(dipJson)
+})
+
 test("dip16 with nosquareplating", () => {
   const circuitJson = fp
     .string("dip16_nosquareplating")


### PR DESCRIPTION
## Summary

- map `PDIP-8` and `pdip8` footprint strings to the existing DIP-8 generator
- add regression coverage for both alias forms

## Why

The DIP footprint implementation already covers the PDIP-8 through-hole package geometry. This adds the missing parser alias so JLCPCB-style `PDIP-8` package strings resolve correctly.

## Tests

- Added tests in `tests/dip.test.ts` comparing `PDIP-8` and `pdip8` against `dip8`.

Fixes #371