### PR TITLE
Add SPDIP-28 footprint alias

### DIFF
--- a/src/footprinter.ts
+++ b/src/footprinter.ts
@@ -271,6 +271,7 @@ const normalizeDefinition = (def: string): string => {
   return def
     .trim()
     .replace(/^pinheader(?=[\d_]|$)/i, "pinrow")
+    .replace(/^spdip-?(\d+)(?=_|$)/i, "dip$1")
     .replace(/^sot23-(\d+)(?=_|$)/i, "sot23_$1")
     .replace(/^sot-223-(\d+)(?=_|$)/i, "sot223_$1")
     .replace(/^to-220f-(\d+)(?=_|$)/i, "to220f_$1")

--- a/tests/dip.test.ts
+++ b/tests/dip.test.ts
@@ -20,6 +20,18 @@ test("DIP16 string resolves using lowercase function", () => {
   const lowercaseJson = fp.string("dip16").json()
   expect(uppercaseJson).toEqual(lowercaseJson)
 })
+
+test("SPDIP-28 string resolves to DIP28", () => {
+  const spdipJson = fp.string("SPDIP-28").json()
+  const dipJson = fp.string("dip28").json()
+  expect(spdipJson).toEqual(dipJson)
+})
+
+test("spdip28 string resolves to DIP28", () => {
+  const spdipJson = fp.string("spdip28").json()
+  const dipJson = fp.string("dip28").json()
+  expect(spdipJson).toEqual(dipJson)
+})
 test("dip16 with nosquareplating", () => {
   const circuitJson = fp
     .string("dip16_nosquareplating")


### PR DESCRIPTION
## Summary
- map `SPDIP-28` and `spdip28` footprint strings to the existing DIP-28 generator
- add regression coverage for both alias forms

## Why
SPDIP-28 is a skinny 28-pin DIP package with the same row spacing/pitch covered by the existing DIP generator. This adds the missing parser alias so JLCPCB-style `SPDIP-28` strings resolve.

## Tests
- Added tests in `tests/dip.test.ts` comparing `SPDIP-28` and `spdip28` against `dip28`.

Fixes #180