### PR TITLE
feat: add UTDFN-4-EP footprint alias

### DIFF
--- a/src/footprinter.ts
+++ b/src/footprinter.ts
@@ -271,7 +271,7 @@ const normalizeDefinition = (def: string): string => {
   return def
     .trim()
     .replace(
-      /^(?:utdfn|udfn)-?(\d+)-ep\((\d+(?:\.\d+)?)x(\d+(?:\.\d+)?)(?:mm)?\)$/i,
+      /^(?:utdfn|udfn)-?(\d+)-ep\((\d+(?:\.\d+)?)x(\d+(?:\.\d+)?)(?:mm)?\)(?=_|$)/i,
       "vson$1-1EP_grid$2x$3mm_P0.5mm_EP0.35x0.6mm_w1.15mm_pinw0.25mm_pinh0.3mm",
     )
     .replace(/^pinheader(?=[\d_]|$)/i, "pinrow")

--- a/src/footprinter.ts
+++ b/src/footprinter.ts
@@ -270,6 +270,10 @@ export type Footprinter = {
 const normalizeDefinition = (def: string): string => {
   return def
     .trim()
+    .replace(
+      /^(?:utdfn|udfn)-?(\d+)-ep\((\d+(?:\.\d+)?)x(\d+(?:\.\d+)?)(?:mm)?\)$/i,
+      "vson$1-1EP_grid$2x$3mm_P0.5mm_EP0.35x0.6mm_w1.15mm_pinw0.25mm_pinh0.3mm",
+    )
     .replace(/^pinheader(?=[\d_]|$)/i, "pinrow")
     .replace(/^sot23-(\d+)(?=_|$)/i, "sot23_$1")
     .replace(/^sot-223-(\d+)(?=_|$)/i, "sot223_$1")

--- a/tests/vson.test.ts
+++ b/tests/vson.test.ts
@@ -64,3 +64,16 @@ test("VSON8_grid3.3x3.3mm_P0.65mm_ep1.9x2.45mm_epx0.385mm_w2.88mm_pinw0.63mm_pin
     "VSON-8_3.3x3.3mm_P0.65mm_NexFET",
   )
 })
+
+test("UTDFN-4-EP(1x1) aliases to a compact VSON footprint", () => {
+  const circuitJson = fp.string("UTDFN-4-EP(1x1)").circuitJson()
+  const params = fp.string("UTDFN-4-EP(1x1)").json() as any
+  const smtPads = circuitJson.filter((el) => el.type === "pcb_smtpad")
+
+  expect(params.fn).toBe("vson")
+  expect(params.num_pins).toBe(4)
+  expect(params.grid).toEqual({ x: 1, y: 1 })
+  expect(params.p).toBe(0.5)
+  expect(params.ep).toEqual({ x: 0.35, y: 0.6 })
+  expect(smtPads).toHaveLength(5)
+})

--- a/tests/vson.test.ts
+++ b/tests/vson.test.ts
@@ -77,3 +77,14 @@ test("UTDFN-4-EP(1x1) aliases to a compact VSON footprint", () => {
   expect(params.ep).toEqual({ x: 0.35, y: 0.6 })
   expect(smtPads).toHaveLength(5)
 })
+
+test("UTDFN-4-EP(1x1) alias preserves trailing options", () => {
+  const params = fp
+    .string("UTDFN-4-EP(1x1)_norefdes_nosilkscreen")
+    .json() as any
+
+  expect(params.fn).toBe("vson")
+  expect(params.num_pins).toBe(4)
+  expect(params.norefdes).toBe(true)
+  expect(params.nosilkscreen).toBe(true)
+})


### PR DESCRIPTION
Refs #183.

Summary:
- Add UTDFN-4-EP(1x1) and UDFN-4-EP(1x1) normalization.
- Route the aliases to compact VSON-style 4-pin exposed-pad geometry.
- Add regression coverage for the new footprint names.

Validation:
- bun x biome format src/footprinter.ts tests/vson.test.ts --write
- bun test tests/vson.test.ts tests/get-footprint-names.test.ts
- bun test
- bun run build
- git diff --check
