### PR TITLE
feat: implement PDIP-8 footprint via pdip/spdip aliases

### DIFF
--- a/src/footprinter.ts
+++ b/src/footprinter.ts
@@ -275,6 +275,8 @@ const normalizeDefinition = (def: string): string => {
     .replace(/^sot-223-(\d+)(?=_|$)/i, "sot223_$1")
     .replace(/^to-220f-(\d+)(?=_|$)/i, "to220f_$1")
     .replace(/^jst_(ph|sh|zh)_(\d+)(?=_|$)/i, "jst$2_$1")
+    .replace(/^pdip(?=[\d_]|$)/i, "dip")
+    .replace(/^spdip(?=[\d_]|$)/i, "dip")
 }
 
 export const string = (def: string): Footprinter => {

--- a/tests/dip.test.ts
+++ b/tests/dip.test.ts
@@ -103,3 +103,27 @@ test("dip_0.1in", () => {
   const svgContent = convertCircuitJsonToPcbSvg(circuitJson)
   expect(svgContent).toMatchSvgSnapshot(import.meta.path, "dip_0.1in")
 })
+
+test("pdip8 string resolves to dip8 footprint", () => {
+  const pdipJson = fp.string("pdip8").json()
+  const dipJson = fp.string("dip8").json()
+  expect(pdipJson).toEqual(dipJson)
+})
+
+test("spdip16 string resolves to dip16 footprint", () => {
+  const spdipJson = fp.string("spdip16").json()
+  const dipJson = fp.string("dip16").json()
+  expect(spdipJson).toEqual(dipJson)
+})
+
+test("PDIP8 uppercase string resolves to dip8 footprint", () => {
+  const uppercaseJson = fp.string("PDIP8").json()
+  const lowercaseJson = fp.string("dip8").json()
+  expect(uppercaseJson).toEqual(lowercaseJson)
+})
+
+test("pdip8_p1.27mm string resolves to dip8_p1.27mm footprint", () => {
+  const pdipJson = fp.string("pdip8_p1.27mm").json()
+  const dipJson = fp.string("dip8_p1.27mm").json()
+  expect(pdipJson).toEqual(dipJson)
+})


### PR DESCRIPTION
## Summary

Closes #371

Adds `pdip` and `spdip` as aliases for the existing `dip` footprint implementation, so that strings like `pdip8`, `PDIP8`, `spdip16`, `pdip8_p1.27mm` all resolve to the same underlying DIP footprint.

## Changes

- `src/footprinter.ts`: Add two regex aliases in `normalizeDefinition`:
  - `^pdip(?=[\d_]|$)` → `dip`
  - `^spdip(?=[\d_]|$)` → `dip`
- `tests/dip.test.ts`: Add 4 test cases covering:
  - Lowercase `pdip8` resolves to `dip8`
  - Lowercase `spdip16` resolves to `dip16`
  - Uppercase `PDIP8` resolves to `dip8` (case-insensitive)
  - Parameterized `pdip8_p1.27mm` resolves to `dip8_p1.27mm`

## Why aliases (not a new function)

`PDIP` (Plastic DIP) and `SPDIP` (Shrink Plastic DIP) are package name variants of the standard DIP family:

- **PDIP**: Same through-hole pad layout and 2.54mm row pitch as standard DIP — only the body material differs (plastic vs ceramic).
- **SPDIP**: Same row pitch as DIP (2.54mm / 0.1in) — slightly narrower body width but pin row spacing is preserved.

For PCB footprint purposes (KiCad JLCPCB libraries, IPC-2221 conventions), they are identical to standard DIP and re-using the existing implementation:
- Keeps the code surface minimal (no duplication of pad geometry)
- Avoids drift between DIP/PDIP/SPDIP implementations
- Matches how KiCad/Altium/Eagle typically treat these as variants of the same footprint

## Verification

All 416 existing tests in the footprinter repo pass:

```
$ bun test
 416 pass
 0 fail
 3 snapshots, 1040 expect() calls
```

Plus 4 new test cases for the aliases.

## /claim #371