### PR TITLE
fix: support pdip and spdip aliases

### DIFF
--- a/src/footprinter.ts
+++ b/src/footprinter.ts
@@ -271,6 +271,7 @@ const normalizeDefinition = (def: string): string => {
   return def
     .trim()
     .replace(/^pinheader(?=[\d_]|$)/i, "pinrow")
+    .replace(/^(?:p|sp)dip-?(\d+)(?=_|$)/i, "dip$1")
     .replace(/^sot23-(\d+)(?=_|$)/i, "sot23_$1")
     .replace(/^sot-223-(\d+)(?=_|$)/i, "sot223_$1")
     .replace(/^to-220f-(\d+)(?=_|$)/i, "to220f_$1")

--- a/tests/dip.test.ts
+++ b/tests/dip.test.ts
@@ -1,7 +1,7 @@
-import { test, expect } from "bun:test"
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
 import { convertCircuitJsonToPcbSvg } from "circuit-to-svg"
 import { fp } from "../src/footprinter"
-import type { AnyCircuitElement } from "circuit-json"
 
 test("dip footprint", () => {
   const circuitJson = fp().dip(4).w(4).p(2).circuitJson()
@@ -20,6 +20,14 @@ test("DIP16 string resolves using lowercase function", () => {
   const lowercaseJson = fp.string("dip16").json()
   expect(uppercaseJson).toEqual(lowercaseJson)
 })
+
+test("PDIP and SPDIP aliases resolve to DIP footprints", () => {
+  expect(fp.string("pdip8").json()).toEqual(fp.string("dip8").json())
+  expect(fp.string("PDIP-8").json()).toEqual(fp.string("dip8").json())
+  expect(fp.string("spdip28").json()).toEqual(fp.string("dip28").json())
+  expect(fp.string("SPDIP-28").json()).toEqual(fp.string("dip28").json())
+})
+
 test("dip16 with nosquareplating", () => {
   const circuitJson = fp
     .string("dip16_nosquareplating")
@@ -81,7 +89,7 @@ test("dip4", () => {
 
 test("dip8_p1.27mm", () => {
   const circuitJson = fp.string("dip8_p1.27mm").circuitJson()
-  let svgContent = convertCircuitJsonToPcbSvg(circuitJson)
+  const svgContent = convertCircuitJsonToPcbSvg(circuitJson)
   expect(svgContent).toMatchSvgSnapshot(import.meta.path, "dip8_p1.27mm")
 })
 


### PR DESCRIPTION
Fixes #371
Fixes #180

@algora-pbc /claim #371
@algora-pbc /claim #180

## Summary
- Normalize `pdip`/`PDIP-*` footprint strings to the existing DIP generator.
- Normalize `spdip`/`SPDIP-*` footprint strings to the existing DIP generator.
- Add regression coverage for lowercase and hyphenated uppercase aliases.

## Verification
- `bun test tests/dip.test.ts tests/jst.test.ts tests/sot223.test.ts`
- `bun run build`
- `bun x biome check src/footprinter.ts tests/dip.test.ts`
- `git diff --check`