### PR TITLE
fix: clarify footprint function errors

### DIFF
--- a/src/footprinter.ts
+++ b/src/footprinter.ts
@@ -277,6 +277,20 @@ const normalizeDefinition = (def: string): string => {
     .replace(/^jst_(ph|sh|zh)_(\d+)(?=_|$)/i, "jst$2_$1")
 }
 
+const createInvalidFootprintFunctionError = (target: any): Error => {
+  if (target.fn) {
+    return new Error(
+      `Function not found for footprinter "${target.fn}". Specify a valid function like .dip, .lr, .p etc.${
+        target.string ? ` From string "${target.string}".` : ""
+      }`,
+    )
+  }
+
+  return new Error(
+    "No footprint function selected. Specify a valid function like .dip, .lr, .p etc.",
+  )
+}
+
 export const string = (def: string): Footprinter => {
   let fp = footprinter()
   const normalizedDef = normalizeDefinition(def)
@@ -363,27 +377,16 @@ export const footprinter = (): Footprinter & {
           }
 
           if (!FOOTPRINT_FN[target.fn]) {
-            throw new Error(
-              `Invalid footprint function, got "${target.fn}"${
-                target.string ? `, from string "${target.string}"` : ""
-              }`,
-            )
+            throw createInvalidFootprintFunctionError(target)
           }
 
           return () => {
-            // TODO improve error
-            throw new Error(
-              `No function found for footprinter, make sure to specify .dip, .lr, .p, etc. Got "${prop}"`,
-            )
+            throw createInvalidFootprintFunctionError(target)
           }
         }
         if (prop === "json") {
           if (!FOOTPRINT_FN[target.fn]) {
-            throw new Error(
-              `Invalid footprint function, got "${target.fn}"${
-                target.string ? `, from string "${target.string}"` : ""
-              }`,
-            )
+            throw createInvalidFootprintFunctionError(target)
           }
           return () => FOOTPRINT_FN[target.fn](target).parameters
         }

--- a/tests/fp-string-error.test.ts
+++ b/tests/fp-string-error.test.ts
@@ -1,8 +1,20 @@
-import { test, expect } from "bun:test"
+import { expect, test } from "bun:test"
 import { fp } from "src/footprinter"
 
 test("fp.string error", () => {
   expect(() => fp.string("nonexistentfn4_p3").circuitJson()).toThrow(
-    'Invalid footprint function, got "nonexistentfn", from string "nonexistentfn4_p3"',
+    'Function not found for footprinter "nonexistentfn". Specify a valid function like .dip, .lr, .p etc. From string "nonexistentfn4_p3".',
+  )
+})
+
+test("fluent invalid function error names the missing function", () => {
+  expect(() => fp().invalid().circuitJson()).toThrow(
+    'Function not found for footprinter "invalid". Specify a valid function like .dip, .lr, .p etc.',
+  )
+})
+
+test("empty footprinter error asks for a valid function", () => {
+  expect(() => fp().circuitJson()).toThrow(
+    "No footprint function selected. Specify a valid function like .dip, .lr, .p etc.",
   )
 })

--- a/tests/vssop.test.ts
+++ b/tests/vssop.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test"
+import { expect, test } from "bun:test"
 import { convertCircuitJsonToPcbSvg } from "circuit-to-svg"
 import { fp } from "../src/footprinter"
 
@@ -123,7 +123,7 @@ test("invalid_vssop6", () => {
   } catch (error) {
     const e = error as Error
     expect(e).toBeInstanceOf(Error)
-    expect(e.message).toContain("Invalid footprint function")
+    expect(e.message).toContain('Function not found for footprinter "invalid"')
   }
 })
 


### PR DESCRIPTION
Fixes #46

Summary
- Add one shared diagnostic for missing/invalid footprint functions.
- Include the missing function name in both string parser and fluent API errors.
- Add regression coverage for string, fluent, and empty footprinter error paths.

Verification
- bun test tests/fp-string-error.test.ts tests/dip.test.ts
- bun x biome check src/footprinter.ts tests/fp-string-error.test.ts
- bun run build
- git diff --check