### PR TITLE
fix: number sot723 pins to match the datasheet (pins 1↔3 were swapped)

### DIFF
--- a/src/fn/sot723.ts
+++ b/src/fn/sot723.ts
@@ -61,12 +61,12 @@ export const getCcwSot723Coords = (parameters: {
   const { pn, w, h, pl, p } = parameters
 
   if (pn === 1) {
-    return { x: p, y: 0 }
+    return { x: -p, y: 0.4 }
   }
   if (pn === 2) {
     return { x: -p, y: -0.4 }
   }
-  return { x: -p, y: 0.4 }
+  return { x: p, y: 0 }
 }
 
 export const sot723WithoutParsing = (

--- a/tests/sot723.test.ts
+++ b/tests/sot723.test.ts
@@ -7,3 +7,19 @@ test("sot723", () => {
   const svgContent = convertCircuitJsonToPcbSvg(soup)
   expect(svgContent).toMatchSvgSnapshot(import.meta.path, "sot723")
 })
+
+test("sot723 numbers pins like the datasheet: 1 top-left, 2 bottom-left, 3 right", () => {
+  const circuitJson = fp.string("sot723").circuitJson() as any[]
+  const pad = (pin: string) =>
+    circuitJson.find(
+      (el) => el.type === "pcb_smtpad" && el.port_hints?.[0] === pin,
+    )
+  // KiCad SOT-723 (Toshiba datasheet): pins 1 and 2 stack on the left
+  // (1 on top), pin 3 sits alone on the right, like sot23/sot323
+  expect(pad("1").x).toBeCloseTo(-0.575)
+  expect(pad("1").y).toBeCloseTo(0.4)
+  expect(pad("2").x).toBeCloseTo(-0.575)
+  expect(pad("2").y).toBeCloseTo(-0.4)
+  expect(pad("3").x).toBeCloseTo(0.575)
+  expect(pad("3").y).toBeCloseTo(0)
+})


### PR DESCRIPTION
## Summary

`sot723` placed its pads at the correct KiCad/Toshiba positions but assigned the pin numbers 1 and 3 to the wrong pads: the lone right pad was numbered **1** and the top-left pad was numbered **3**. Every other 3-pin SOT in this repo (`sot23`, `sot23w`, `sot323`) and KiCad's official `SOT-723.kicad_mod` (which references the Toshiba datasheet) use the standard arrangement: **pin 1 top-left, pin 2 bottom-left, pin 3 alone on the right**. A real part placed on this footprint gets cross-wired (e.g. base↔collector on a transistor).

This never showed in SVG snapshots or the KiCad parity test because both only compare copper shapes — pin numbers aren't rendered.

Fixes tscircuit/footprinter#686

## Expected vs actual (default params)

| pin | before | after (= KiCad SOT-723) |
|---|---|---|
| 1 | (+0.575, 0) — right ❌ | (−0.575, +0.4) — top-left |
| 2 | (−0.575, −0.4) ✅ | unchanged |
| 3 | (−0.575, +0.4) — top-left ❌ | (+0.575, 0) — right |

The pad positions, sizes (0.45 × 0.4) and pitch (±0.575) already matched KiCad exactly — this PR only fixes which number each pad carries. Introduced in #404, which fixed the pad positions but kept the old pin→pad assignment.

## Changes

- `src/fn/sot723.ts`: two-line swap in `getCcwSot723Coords` — pin 1 now takes the top-left spot and pin 3 the lone right spot (the order now actually runs counterclockwise, as the helper's name says)
- `tests/sot723.test.ts`: added a pin-to-position assertion so this can't regress invisibly again

## Testing

- New test fails on `main` (verified against the unfixed code) and passes with the fix
- Full suite: 432 pass, 0 fail — no snapshot changes (copper is identical, only pin numbering changed)
- `tests/kicad-parity/sot723_kicad_parity.test.ts` still passes with 100% courtyard IoU
- `bun run build` and `bun run format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)