### PR TITLE
feat: add pdip aliases for dip footprints

### DIFF
--- a/src/footprinter.ts
+++ b/src/footprinter.ts
@@ -532,6 +532,8 @@ const normalizeDefinition = (def: string): string => {
     .replace(/^to-263(?:-(\d+))?(?=_|$)/i, (_, pins) =>
       pins ? `to263_${pins}` : "to263",
     )
+    .replace(/^s?pdip-(\d+)(?=[\d_]|$)/i, "dip$1")
+    .replace(/^s?pdip(?=[\d_]|$)/i, "dip")
     .replace(/^sot23-(\d+)(?=_|$)/i, "sot23_$1")
     .replace(/^sot-223-(\d+)(?=_|$)/i, "sot223_$1")
     .replace(/^to-220f-(\d+)(?=_|$)/i, "to220f_$1")

--- a/tests/dip.test.ts
+++ b/tests/dip.test.ts
@@ -1,7 +1,7 @@
-import { test, expect } from "bun:test"
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
 import { convertCircuitJsonToPcbSvg } from "circuit-to-svg"
 import { fp } from "../src/footprinter"
-import type { AnyCircuitElement } from "circuit-json"
 
 test("dip footprint", () => {
   const circuitJson = fp().dip(4).w(4).p(2).circuitJson()
@@ -54,6 +54,12 @@ test("DIP16 string resolves using lowercase function", () => {
   const lowercaseJson = fp.string("dip16").json()
   expect(uppercaseJson).toEqual(lowercaseJson)
 })
+
+test("PDIP aliases resolve to DIP", () => {
+  expect(fp.string("PDIP-8").json()).toEqual(fp.string("dip8").json())
+  expect(fp.string("spdip8").json()).toEqual(fp.string("dip8").json())
+})
+
 test("dip16 with nosquareplating", () => {
   const circuitJson = fp
     .string("dip16_nosquareplating")
@@ -115,7 +121,7 @@ test("dip4", () => {
 
 test("dip8_p1.27mm", () => {
   const circuitJson = fp.string("dip8_p1.27mm").circuitJson()
-  let svgContent = convertCircuitJsonToPcbSvg(circuitJson)
+  const svgContent = convertCircuitJsonToPcbSvg(circuitJson)
   expect(svgContent).toMatchSvgSnapshot(import.meta.path, "dip8_p1.27mm")
 })
 


### PR DESCRIPTION
Adds PDIP/SPDIP aliases that normalize to the existing DIP footprint implementation, with tests for PDIP-8 parsing and parser stability.\n\n/claim #371