### PR TITLE
fix: add spdip alias

### DIFF
--- a/src/footprinter.ts
+++ b/src/footprinter.ts
@@ -534,6 +534,7 @@ const normalizeDefinition = (def: string): string => {
     )
     .replace(/^sot23-(\d+)(?=_|$)/i, "sot23_$1")
     .replace(/^sot-223-(\d+)(?=_|$)/i, "sot223_$1")
+    .replace(/^spdip-(\d+)(?=_|$)/i, "dip$1")
     .replace(/^to-220f-(\d+)(?=_|$)/i, "to220f_$1")
     .replace(/^jst_(ph|sh|zh)_(\d+)(?=_|$)/i, "jst$2_$1")
 }

--- a/tests/dip.test.ts
+++ b/tests/dip.test.ts
@@ -1,7 +1,7 @@
-import { test, expect } from "bun:test"
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
 import { convertCircuitJsonToPcbSvg } from "circuit-to-svg"
 import { fp } from "../src/footprinter"
-import type { AnyCircuitElement } from "circuit-json"
 
 test("dip footprint", () => {
   const circuitJson = fp().dip(4).w(4).p(2).circuitJson()
@@ -65,6 +65,12 @@ test("dip16 with nosquareplating", () => {
   )
 })
 
+test("SPDIP-28 alias", () => {
+  const aliasJson = fp.string("SPDIP-28").json()
+  const canonicalJson = fp.string("dip28").json()
+  expect(aliasJson).toEqual(canonicalJson)
+})
+
 test("dip4_w3.00mm", () => {
   const circuitJson = fp
     .string("dip4_w3.00mm")
@@ -115,7 +121,7 @@ test("dip4", () => {
 
 test("dip8_p1.27mm", () => {
   const circuitJson = fp.string("dip8_p1.27mm").circuitJson()
-  let svgContent = convertCircuitJsonToPcbSvg(circuitJson)
+  const svgContent = convertCircuitJsonToPcbSvg(circuitJson)
   expect(svgContent).toMatchSvgSnapshot(import.meta.path, "dip8_p1.27mm")
 })
 


### PR DESCRIPTION
Adds SPDIP-28 as an alias for the existing DIP footprint and verifies it matches the canonical dip28 output.\n\n/claim #180