### PR TITLE
Infer reflected pin 1 orientations

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,9 @@ fp.string("dip4_w0.3in") // same as fp.dip(4).w("0.3in")
 
 ### Pin 1 location
 
-Every footprint accepts a `pin1location(side,alignment)` modifier that rotates
-the complete footprint in 90-degree increments. The first argument selects the
-side, while the second selects the position along that side:
+Every footprint accepts a `pin1location(side,alignment)` modifier that orients
+the complete footprint. The first argument selects the side, while the second
+selects the position along that side:
 
 ```ts
 fp.string("soic8_pin1location(leftside,top)")
@@ -90,8 +90,10 @@ fp().crystal().pin1location("topside", "left")
 ```
 
 Valid pairs are `leftside|rightside` with `top|bottom`, and
-`topside|bottomside` with `left|right`. Rotation preserves pin ordering, so a
-mirrored-only location is rejected with an error.
+`topside|bottomside` with `left|right`. Footprinter evaluates all four rotations
+and their reflected equivalents, preferring rotation when possible and
+inferring a reflection when the requested side/alignment implies reversed pin
+ordering.
 
 ## Getting JSON output from the builder
 

--- a/src/helpers/apply-pin1-location.ts
+++ b/src/helpers/apply-pin1-location.ts
@@ -1,10 +1,24 @@
 import type { AnyCircuitElement } from "circuit-json"
-import type { Pin1Location } from "./zod/pin1-location"
+import type { Pin1Alignment, Pin1Location, Pin1Side } from "./zod/pin1-location"
 
 type RightAngleRotation = 0 | 90 | 180 | 270
 type Point = { x: number; y: number }
+type FootprintTransform = {
+  rotation: RightAngleRotation
+  mirrored: boolean
+}
 
 const RIGHT_ANGLE_ROTATIONS: RightAngleRotation[] = [0, 90, 180, 270]
+const FOOTPRINT_TRANSFORMS: FootprintTransform[] = [
+  ...RIGHT_ANGLE_ROTATIONS.map((rotation) => ({
+    rotation,
+    mirrored: false,
+  })),
+  ...RIGHT_ANGLE_ROTATIONS.map((rotation) => ({
+    rotation,
+    mirrored: true,
+  })),
+]
 
 const rotatePoint = (point: Point, rotation: RightAngleRotation): Point => {
   switch (rotation) {
@@ -18,6 +32,12 @@ const rotatePoint = (point: Point, rotation: RightAngleRotation): Point => {
       return { ...point }
   }
 }
+
+const transformPoint = (
+  point: Point,
+  { rotation, mirrored }: FootprintTransform,
+): Point =>
+  rotatePoint(mirrored ? { x: -point.x, y: point.y } : point, rotation)
 
 const getPadCenter = (pad: any): Point | null => {
   if (typeof pad.x === "number" && typeof pad.y === "number") {
@@ -39,11 +59,19 @@ const getPadCenter = (pad: any): Point | null => {
 const isPin1 = (pad: any) =>
   pad.port_hints?.some((hint: unknown) => /^(?:pin)?1$/i.test(String(hint)))
 
-const pinMatchesLocation = (
+const getPinNumber = (pad: any): number | null => {
+  for (const hint of pad.port_hints ?? []) {
+    const match = String(hint).match(/^(?:pin)?(\d+)$/i)
+    if (match) return Number(match[1])
+  }
+  return null
+}
+
+const inferPin1Location = (
   padCenters: Point[],
   pin1Center: Point,
-  [side, alignment]: Pin1Location,
-) => {
+  nextPinCenter: Point | null,
+): { side: Pin1Side; alignment?: Pin1Alignment } | null => {
   const xs = padCenters.map((point) => point.x)
   const ys = padCenters.map((point) => point.y)
   const minX = Math.min(...xs)
@@ -56,26 +84,62 @@ const pinMatchesLocation = (
   const spanY = maxY - minY
   const tolerance = Math.max(spanX, spanY, 1) * 1e-6
 
-  const onRequestedSide =
-    (side === "leftside" && Math.abs(pin1Center.x - minX) <= tolerance) ||
-    (side === "rightside" && Math.abs(pin1Center.x - maxX) <= tolerance) ||
-    (side === "topside" && Math.abs(pin1Center.y - maxY) <= tolerance) ||
-    (side === "bottomside" && Math.abs(pin1Center.y - minY) <= tolerance)
+  const candidates: Pin1Side[] = []
+  if (spanX > tolerance) {
+    if (Math.abs(pin1Center.x - minX) <= tolerance) candidates.push("leftside")
+    if (Math.abs(pin1Center.x - maxX) <= tolerance) candidates.push("rightside")
+  }
+  if (spanY > tolerance) {
+    if (Math.abs(pin1Center.y - maxY) <= tolerance) candidates.push("topside")
+    if (Math.abs(pin1Center.y - minY) <= tolerance)
+      candidates.push("bottomside")
+  }
 
-  const atRequestedAlignment =
-    (alignment === "left" &&
-      (spanX <= tolerance || pin1Center.x < centerX - tolerance)) ||
-    (alignment === "right" &&
-      (spanX <= tolerance || pin1Center.x > centerX + tolerance)) ||
-    (alignment === "top" &&
-      (spanY <= tolerance || pin1Center.y > centerY + tolerance)) ||
-    (alignment === "bottom" &&
-      (spanY <= tolerance || pin1Center.y < centerY - tolerance))
+  if (candidates.length === 0) return null
 
-  return onRequestedSide && atRequestedAlignment
+  const isOnSide = (point: Point, side: Pin1Side) =>
+    (side === "leftside" && Math.abs(point.x - minX) <= tolerance) ||
+    (side === "rightside" && Math.abs(point.x - maxX) <= tolerance) ||
+    (side === "topside" && Math.abs(point.y - maxY) <= tolerance) ||
+    (side === "bottomside" && Math.abs(point.y - minY) <= tolerance)
+
+  const nextPinCandidates = nextPinCenter
+    ? candidates.filter((side) => isOnSide(nextPinCenter, side))
+    : []
+
+  let side: Pin1Side
+  if (nextPinCandidates.length === 1) {
+    side = nextPinCandidates[0]!
+  } else {
+    const rankedCandidates = candidates
+      .map((candidate) => ({
+        side: candidate,
+        count: padCenters.filter((point) => isOnSide(point, candidate)).length,
+      }))
+      .sort((a, b) => b.count - a.count)
+    if (
+      rankedCandidates.length > 1 &&
+      rankedCandidates[0]!.count === rankedCandidates[1]!.count
+    ) {
+      return null
+    }
+    side = rankedCandidates[0]!.side
+  }
+
+  if (side === "leftside" || side === "rightside") {
+    if (spanY <= tolerance) return { side }
+    if (pin1Center.y > centerY + tolerance) return { side, alignment: "top" }
+    if (pin1Center.y < centerY - tolerance) return { side, alignment: "bottom" }
+  } else {
+    if (spanX <= tolerance) return { side }
+    if (pin1Center.x < centerX - tolerance) return { side, alignment: "left" }
+    if (pin1Center.x > centerX + tolerance) return { side, alignment: "right" }
+  }
+
+  return null
 }
 
-const rotatePointField = (value: unknown, rotation: RightAngleRotation) => {
+const transformPointField = (value: unknown, transform: FootprintTransform) => {
   if (
     !value ||
     typeof value !== "object" ||
@@ -85,51 +149,120 @@ const rotatePointField = (value: unknown, rotation: RightAngleRotation) => {
     return
   }
 
-  const rotated = rotatePoint(value as Point, rotation)
-  ;(value as Point).x = rotated.x
-  ;(value as Point).y = rotated.y
+  const transformed = transformPoint(value as Point, transform)
+  ;(value as Point).x = transformed.x
+  ;(value as Point).y = transformed.y
 }
 
 const normalizeRotation = (rotation: number) => ((rotation % 360) + 360) % 360
 
-const rotateElements = (
-  elements: AnyCircuitElement[],
-  rotation: RightAngleRotation,
+const transformRotation = (rotation: number, transform: FootprintTransform) =>
+  normalizeRotation(
+    transform.rotation + (transform.mirrored ? -rotation : rotation),
+  )
+
+const ANCHOR_ALIGNMENT_POINTS: Record<string, Point> = {
+  top_left: { x: -1, y: 1 },
+  top_center: { x: 0, y: 1 },
+  top_right: { x: 1, y: 1 },
+  center_left: { x: -1, y: 0 },
+  center: { x: 0, y: 0 },
+  center_right: { x: 1, y: 0 },
+  bottom_left: { x: -1, y: -1 },
+  bottom_center: { x: 0, y: -1 },
+  bottom_right: { x: 1, y: -1 },
+}
+
+const transformAnchorAlignment = (
+  anchorAlignment: unknown,
+  transform: FootprintTransform,
 ) => {
-  if (rotation === 0) return elements
+  if (typeof anchorAlignment !== "string") return anchorAlignment
+  const point = ANCHOR_ALIGNMENT_POINTS[anchorAlignment]
+  if (!point) return anchorAlignment
+  const transformed = transformPoint(point, transform)
+  return Object.entries(ANCHOR_ALIGNMENT_POINTS).find(
+    ([, candidate]) =>
+      candidate.x === transformed.x && candidate.y === transformed.y,
+  )?.[0]
+}
 
-  const rotatedElements = structuredClone(elements)
+const transformElements = (
+  elements: AnyCircuitElement[],
+  transform: FootprintTransform,
+) => {
+  if (transform.rotation === 0 && !transform.mirrored) return elements
 
-  for (const element of rotatedElements as any[]) {
+  const transformedElements = structuredClone(elements)
+
+  for (const element of transformedElements as any[]) {
     if (typeof element.x === "number" && typeof element.y === "number") {
-      const rotated = rotatePoint(element, rotation)
-      element.x = rotated.x
-      element.y = rotated.y
+      const transformed = transformPoint(element, transform)
+      element.x = transformed.x
+      element.y = transformed.y
     }
 
-    rotatePointField(element.center, rotation)
-    rotatePointField(element.anchor_position, rotation)
+    transformPointField(element.center, transform)
+    transformPointField(element.anchor_position, transform)
+
+    if (
+      typeof element.hole_offset_x === "number" &&
+      typeof element.hole_offset_y === "number"
+    ) {
+      const transformedOffset = transformPoint(
+        { x: element.hole_offset_x, y: element.hole_offset_y },
+        transform,
+      )
+      element.hole_offset_x = transformedOffset.x
+      element.hole_offset_y = transformedOffset.y
+    }
 
     for (const field of ["route", "outline", "points"] as const) {
       if (!Array.isArray(element[field])) continue
       for (const point of element[field]) {
-        rotatePointField(point, rotation)
+        transformPointField(point, transform)
       }
     }
 
     if (
       (element.type === "pcb_smtpad" && element.shape !== "polygon") ||
       element.type === "pcb_plated_hole" ||
-      element.type === "pcb_silkscreen_text" ||
-      element.type === "pcb_fabrication_note_text"
+      element.type === "pcb_silkscreen_text"
     ) {
-      element.ccw_rotation = normalizeRotation(
-        Number(element.ccw_rotation ?? 0) + rotation,
+      element.ccw_rotation = transformRotation(
+        Number(element.ccw_rotation ?? 0),
+        transform,
+      )
+    }
+
+    for (const field of [
+      "hole_ccw_rotation",
+      "rect_ccw_rotation",
+      "text_ccw_rotation",
+    ] as const) {
+      if (typeof element[field] === "number") {
+        element[field] = transformRotation(element[field], transform)
+      }
+    }
+
+    if (element.anchor_alignment) {
+      element.anchor_alignment = transformAnchorAlignment(
+        element.anchor_alignment,
+        transform,
       )
     }
 
     if (
-      (rotation === 90 || rotation === 270) &&
+      transform.mirrored &&
+      (element.type === "pcb_silkscreen_text" ||
+        element.type === "pcb_copper_text" ||
+        element.type === "pcb_text")
+    ) {
+      element.is_mirrored = !element.is_mirrored
+    }
+
+    if (
+      (transform.rotation === 90 || transform.rotation === 270) &&
       (element.type === "pcb_courtyard_rect" ||
         element.type === "pcb_silkscreen_rect" ||
         element.type === "pcb_fabrication_note_rect" ||
@@ -137,9 +270,20 @@ const rotateElements = (
     ) {
       ;[element.width, element.height] = [element.height, element.width]
     }
+
+    if (
+      (transform.rotation === 90 || transform.rotation === 270) &&
+      element.type === "pcb_plated_hole" &&
+      element.shape === "circular_hole_with_rect_pad"
+    ) {
+      ;[element.rect_pad_width, element.rect_pad_height] = [
+        element.rect_pad_height,
+        element.rect_pad_width,
+      ]
+    }
   }
 
-  return rotatedElements
+  return transformedElements
 }
 
 export const applyPin1Location = (
@@ -153,8 +297,13 @@ export const applyPin1Location = (
       element.type === "pcb_smtpad" || element.type === "pcb_plated_hole",
   )
   const pin1 = pads.find(isPin1)
+  const nextPin = pads
+    .map((pad) => ({ pad, pinNumber: getPinNumber(pad) }))
+    .filter(({ pinNumber }) => pinNumber !== null && pinNumber > 1)
+    .sort((a, b) => a.pinNumber! - b.pinNumber!)[0]?.pad
   const padCenters = pads.map(getPadCenter).filter((point) => point !== null)
   const pin1Center = pin1 ? getPadCenter(pin1) : null
+  const nextPinCenter = nextPin ? getPadCenter(nextPin) : null
 
   if (!pin1 || !pin1Center || padCenters.length === 0) {
     throw new Error(
@@ -162,19 +311,31 @@ export const applyPin1Location = (
     )
   }
 
-  const rotation = RIGHT_ANGLE_ROTATIONS.find((candidateRotation) => {
-    const rotatedPads = padCenters.map((point) =>
-      rotatePoint(point, candidateRotation),
+  const transform = FOOTPRINT_TRANSFORMS.find((candidateTransform) => {
+    const transformedPads = padCenters.map((point) =>
+      transformPoint(point, candidateTransform),
     )
-    const rotatedPin1 = rotatePoint(pin1Center, candidateRotation)
-    return pinMatchesLocation(rotatedPads, rotatedPin1, pin1Location)
+    const transformedPin1 = transformPoint(pin1Center, candidateTransform)
+    const transformedNextPin = nextPinCenter
+      ? transformPoint(nextPinCenter, candidateTransform)
+      : null
+    const inferredLocation = inferPin1Location(
+      transformedPads,
+      transformedPin1,
+      transformedNextPin,
+    )
+    return (
+      inferredLocation?.side === pin1Location[0] &&
+      (inferredLocation.alignment === undefined ||
+        inferredLocation.alignment === pin1Location[1])
+    )
   })
 
-  if (rotation === undefined) {
+  if (transform === undefined) {
     throw new Error(
-      `pin1location(${pin1Location.join(",")}) cannot be reached with a rotation; the requested location may be the mirrored orientation of this footprint`,
+      `pin1location(${pin1Location.join(",")}) cannot be inferred from this footprint's pad layout`,
     )
   }
 
-  return rotateElements(elements, rotation)
+  return transformElements(elements, transform)
 }

--- a/tests/pin1-location.test.ts
+++ b/tests/pin1-location.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test"
 import { fp } from "../src/footprinter"
+import { applyPin1Location } from "../src/helpers/apply-pin1-location"
 
 const getPads = (
   circuitJson: ReturnType<ReturnType<typeof fp>["circuitJson"]>,
@@ -23,7 +24,7 @@ test("pin1location(leftside,top) leaves an already matching SOIC unchanged", () 
   expect(positioned).toEqual(original)
 })
 
-test("pin1location(topside,left) rotates a complete footprint", () => {
+test("pin1location(topside,left) orients a complete footprint", () => {
   const original = fp.string("crystal").circuitJson() as any[]
   const positioned = fp
     .string("crystal_pin1location(topside,left)")
@@ -42,16 +43,20 @@ test("pin1location(topside,left) rotates a complete footprint", () => {
   const silkAfter = positioned.find(
     (element) => element.type === "pcb_silkscreen_path",
   )
+  const refdesAfter = positioned.find(
+    (element) => element.type === "pcb_silkscreen_text",
+  )
 
   expect(pin1.y).toBe(Math.max(...pads.map((pad) => pad.y)))
   expect(pin1.x).toBeLessThan(0)
-  expect(pin1.ccw_rotation).toBe(270)
-  expect(courtyardAfter.width).toBe(courtyardBefore.height)
-  expect(courtyardAfter.height).toBe(courtyardBefore.width)
+  expect(pin1.ccw_rotation).toBe(180)
+  expect(courtyardAfter.width).toBe(courtyardBefore.width)
+  expect(courtyardAfter.height).toBe(courtyardBefore.height)
   expect(silkAfter.route[0]).toEqual({
-    x: silkBefore.route[0].y,
-    y: -silkBefore.route[0].x,
+    x: silkBefore.route[0].x,
+    y: -silkBefore.route[0].y,
   })
+  expect(refdesAfter.is_mirrored).toBe(true)
 })
 
 test("the builder API supports the global pin1location property", () => {
@@ -97,11 +102,107 @@ test("polygon pad points rotate without applying a second pad rotation", () => {
   expect(polygonAfter.ccw_rotation).toBeUndefined()
 })
 
-test("pin1location rejects invalid and mirrored-only locations", () => {
+test("pin1location infers reflection from the requested pin ordering", () => {
+  const positioned = fp
+    .string("qfp16_pin1location(topside,left)")
+    .circuitJson() as any[]
+  const pin1 = getPin1(positioned)
+  const pin2 = getPads(positioned).find((pad) => pad.port_hints?.includes("2"))!
+  const refdes = positioned.find(
+    (element) => element.type === "pcb_silkscreen_text",
+  )
+
+  expect(pin1.y).toBe(Math.max(...getPads(positioned).map((pad) => pad.y)))
+  expect(pin1.x).toBeLessThan(0)
+  expect(pin2.y).toBe(pin1.y)
+  expect(pin2.x).toBeGreaterThan(pin1.x)
+  expect(refdes.is_mirrored).toBe(true)
+})
+
+test("pin ordering disambiguates the side of a corner pin", () => {
+  const original = fp.string("dip8_pin1location(leftside,top)").circuitJson()
+  const positioned = fp.string("dip8_pin1location(topside,left)").circuitJson()
+  const pin1 = getPin1(positioned)
+  const pin2 = getPads(positioned).find((pad) => pad.port_hints?.includes("2"))!
+
+  expect(original).toEqual(fp.string("dip8").circuitJson())
+  expect(pin2.y).toBe(pin1.y)
+  expect(pin2.x).toBeGreaterThan(pin1.x)
+})
+
+test("reflections transform existing rotations and anchor alignment", () => {
+  const positioned = applyPin1Location(
+    [
+      {
+        type: "pcb_smtpad",
+        shape: "rect",
+        x: -2,
+        y: 1,
+        width: 1,
+        height: 0.5,
+        layer: "top",
+        pcb_smtpad_id: "",
+        port_hints: ["1"],
+      },
+      {
+        type: "pcb_smtpad",
+        shape: "rect",
+        x: -2,
+        y: -1,
+        width: 1,
+        height: 0.5,
+        layer: "top",
+        pcb_smtpad_id: "",
+        port_hints: ["2"],
+      },
+      {
+        type: "pcb_smtpad",
+        shape: "rect",
+        x: 2,
+        y: -1,
+        width: 1,
+        height: 0.5,
+        layer: "top",
+        pcb_smtpad_id: "",
+        port_hints: ["3"],
+      },
+      {
+        type: "pcb_smtpad",
+        shape: "rect",
+        x: 2,
+        y: 2,
+        width: 1,
+        height: 0.5,
+        layer: "top",
+        pcb_smtpad_id: "",
+        port_hints: ["4"],
+      },
+      {
+        type: "pcb_silkscreen_text",
+        pcb_silkscreen_text_id: "",
+        pcb_component_id: "",
+        font: "tscircuit2024",
+        font_size: 0.3,
+        text: "REF",
+        layer: "top",
+        anchor_position: { x: 1, y: 1 },
+        anchor_alignment: "top_right",
+        ccw_rotation: 30,
+      },
+    ],
+    ["topside", "left"],
+  ) as any[]
+  const text = positioned.find(
+    (element) => element.type === "pcb_silkscreen_text",
+  )
+
+  expect(text.ccw_rotation).toBe(60)
+  expect(text.is_mirrored).toBe(true)
+  expect(text.anchor_alignment).toBe("bottom_left")
+})
+
+test("pin1location rejects invalid side and alignment pairs", () => {
   expect(() =>
     fp.string("crystal_pin1location(leftside,left)").circuitJson(),
   ).toThrow()
-  expect(() =>
-    fp.string("qfp16_pin1location(topside,left)").circuitJson(),
-  ).toThrow(/cannot be reached with a rotation/)
 })


### PR DESCRIPTION
## Summary

Follow-up to #714.

- infer pin 1's actual side from pin ordering, so corner pads distinguish cases such as `leftside,top` from `topside,left`
- evaluate all four rotations and their reflected equivalents, preferring a rotation and reflecting when the requested orientation implies reversed pin ordering
- transform reflected footprint geometry consistently, including pad/hole rotations, paths, polygons, text mirroring and anchor alignment, courtyards, and rectangular cutouts
- update the documentation to describe ordering-aware reflection inference

For example, DIP pin 1 at the upper-left is inferred as `leftside,top` because pin 2 continues downward. Requesting `topside,left` reflects the footprint so pin 2 continues rightward.

## Validation

- `bun test` — 452 pass, 0 fail
- focused pin-location tests — 9 pass, 0 fail
- `bun run build` — ESM and DTS builds pass
- all eight orientations exercised across SOIC, DIP, QFP, crystal, SOT-23, BGA, passive, pin-row, and radial footprints
- Biome checks on changed files
- `git diff --check`
