### PR TITLE
Add fast semantic pin 1 location analysis

### DIFF
--- a/src/helpers/apply-pin1-location.ts
+++ b/src/helpers/apply-pin1-location.ts
@@ -5,6 +5,16 @@ type RightAngleRotation = 0 | 90 | 180 | 270
 type Point = { x: number; y: number }
 
 const RIGHT_ANGLE_ROTATIONS: RightAngleRotation[] = [0, 90, 180, 270]
+const PIN1_LOCATIONS: Pin1Location[] = [
+  ["leftside", "top"],
+  ["leftside", "bottom"],
+  ["rightside", "top"],
+  ["rightside", "bottom"],
+  ["topside", "left"],
+  ["topside", "right"],
+  ["bottomside", "left"],
+  ["bottomside", "right"],
+]
 
 const rotatePoint = (point: Point, rotation: RightAngleRotation): Point => {
   switch (rotation) {
@@ -38,6 +48,16 @@ const getPadCenter = (pad: any): Point | null => {
 
 const isPin1 = (pad: any) =>
   pad.port_hints?.some((hint: unknown) => /^(?:pin)?1$/i.test(String(hint)))
+
+const getPinNumber = (pad: any): number | null => {
+  for (const hint of pad.port_hints ?? []) {
+    const match = String(hint)
+      .trim()
+      .match(/^(?:pin)?(\d+)$/i)
+    if (match) return Number.parseInt(match[1]!, 10)
+  }
+  return null
+}
 
 const pinMatchesLocation = (
   padCenters: Point[],
@@ -73,6 +93,57 @@ const pinMatchesLocation = (
       (spanY <= tolerance || pin1Center.y < centerY - tolerance))
 
   return onRequestedSide && atRequestedAlignment
+}
+
+/**
+ * Infers the semantic pin 1 location from pad positions and numeric port hints.
+ * Returns null when pin 1 is missing or the geometry cannot distinguish a
+ * rotation from a reflection.
+ */
+export const analyzePin1Location = (
+  elements: readonly AnyCircuitElement[],
+): Pin1Location | null => {
+  const pads = (elements as readonly any[]).filter(
+    (element) =>
+      element.type === "pcb_smtpad" || element.type === "pcb_plated_hole",
+  )
+  const pin1 = pads.find(isPin1)
+  const pin1Center = pin1 ? getPadCenter(pin1) : null
+  const padCenters = pads.map(getPadCenter).filter((point) => point !== null)
+  if (!pin1Center || padCenters.length === 0) return null
+
+  const candidates = PIN1_LOCATIONS.filter((location) =>
+    pinMatchesLocation(padCenters, pin1Center, location),
+  )
+  if (candidates.length === 1) return candidates[0]!
+  if (candidates.length === 0) return null
+
+  const nextNumberedPad = pads
+    .map((pad) => ({ center: getPadCenter(pad), pinNumber: getPinNumber(pad) }))
+    .filter(
+      (entry): entry is { center: Point; pinNumber: number } =>
+        entry.center !== null &&
+        entry.pinNumber !== null &&
+        entry.pinNumber > 1,
+    )
+    .toSorted((a, b) => a.pinNumber - b.pinNumber)[0]
+  if (!nextNumberedPad) return null
+
+  const xs = padCenters.map((point) => point.x)
+  const ys = padCenters.map((point) => point.y)
+  const span = Math.max(
+    Math.max(...xs) - Math.min(...xs),
+    Math.max(...ys) - Math.min(...ys),
+    1,
+  )
+  const tolerance = span * 1e-6
+  const topologyCandidates = candidates.filter(([side]) =>
+    side === "leftside" || side === "rightside"
+      ? Math.abs(nextNumberedPad.center.x - pin1Center.x) <= tolerance
+      : Math.abs(nextNumberedPad.center.y - pin1Center.y) <= tolerance,
+  )
+
+  return topologyCandidates.length === 1 ? topologyCandidates[0]! : null
 }
 
 const rotatePointField = (value: unknown, rotation: RightAngleRotation) => {

--- a/src/helpers/apply-pin1-location.ts
+++ b/src/helpers/apply-pin1-location.ts
@@ -4,6 +4,14 @@ import type { Pin1Location } from "./zod/pin1-location"
 type RightAngleRotation = 0 | 90 | 180 | 270
 type Point = { x: number; y: number }
 
+export interface Pin1LocationElement {
+  type: string
+  x?: number
+  y?: number
+  points?: readonly Point[]
+  port_hints?: readonly unknown[]
+}
+
 const RIGHT_ANGLE_ROTATIONS: RightAngleRotation[] = [0, 90, 180, 270]
 const PIN1_LOCATIONS: Pin1Location[] = [
   ["leftside", "top"],
@@ -101,9 +109,9 @@ const pinMatchesLocation = (
  * rotation from a reflection.
  */
 export const analyzePin1Location = (
-  elements: readonly AnyCircuitElement[],
+  elements: readonly Pin1LocationElement[],
 ): Pin1Location | null => {
-  const pads = (elements as readonly any[]).filter(
+  const pads = elements.filter(
     (element) =>
       element.type === "pcb_smtpad" || element.type === "pcb_plated_hole",
   )

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,3 @@
 export * from "./footprinter"
+export { analyzePin1Location } from "./helpers/apply-pin1-location"
+export type { Pin1Location } from "./helpers/zod/pin1-location"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,6 @@
 export * from "./footprinter"
-export { analyzePin1Location } from "./helpers/apply-pin1-location"
+export {
+  analyzePin1Location,
+  type Pin1LocationElement,
+} from "./helpers/apply-pin1-location"
 export type { Pin1Location } from "./helpers/zod/pin1-location"

--- a/tests/analyze-pin1-location.test.ts
+++ b/tests/analyze-pin1-location.test.ts
@@ -1,0 +1,74 @@
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { analyzePin1Location } from "../src"
+
+const createPad = (pinNumber: number, x: number, y: number) =>
+  ({
+    type: "pcb_smtpad",
+    shape: "rect",
+    pcb_smtpad_id: `pcb_smtpad_${pinNumber}`,
+    x,
+    y,
+    width: 0.5,
+    height: 1,
+    layer: "top",
+    port_hints: [`pin${pinNumber}`],
+  }) as AnyCircuitElement
+
+const rotatePads = (pads: AnyCircuitElement[], rotation: 0 | 90 | 180 | 270) =>
+  pads.map((pad) => {
+    if (!("x" in pad) || !("y" in pad)) return pad
+    const { x, y } = pad
+    const center =
+      rotation === 90
+        ? { x: -y, y: x }
+        : rotation === 180
+          ? { x: -x, y: -y }
+          : rotation === 270
+            ? { x: y, y: -x }
+            : { x, y }
+    return { ...pad, ...center }
+  })
+
+test("analyzes all rotations of a two-sided footprint", () => {
+  const pads = [
+    createPad(1, -2, 1),
+    createPad(2, -2, -1),
+    createPad(3, 2, -1),
+    createPad(4, 2, 1),
+  ]
+
+  expect(analyzePin1Location(rotatePads(pads, 0))).toEqual(["leftside", "top"])
+  expect(analyzePin1Location(rotatePads(pads, 90))).toEqual([
+    "bottomside",
+    "left",
+  ])
+  expect(analyzePin1Location(rotatePads(pads, 180))).toEqual([
+    "rightside",
+    "bottom",
+  ])
+  expect(analyzePin1Location(rotatePads(pads, 270))).toEqual([
+    "topside",
+    "right",
+  ])
+})
+
+test("uses pin 2 topology to distinguish a reflected corner", () => {
+  const pads = [
+    createPad(1, -1, 1),
+    createPad(2, 1, 1),
+    createPad(3, 1, -1),
+    createPad(4, -1, -1),
+  ]
+
+  expect(analyzePin1Location(pads)).toEqual(["topside", "left"])
+})
+
+test("returns null for ambiguous linear footprints and missing pin 1", () => {
+  expect(
+    analyzePin1Location([createPad(1, -1, 0), createPad(2, 1, 0)]),
+  ).toBeNull()
+  expect(
+    analyzePin1Location([createPad(2, -1, 0), createPad(3, 1, 0)]),
+  ).toBeNull()
+})


### PR DESCRIPTION
## Summary

- export `analyzePin1Location` from `@tscircuit/footprinter`
- infer side/alignment from PCB pad geometry and numeric port hints in O(pads) time
- use the next numbered pad to distinguish rotation-compatible corner locations from reflected topology
- return `null` for missing or genuinely ambiguous pin-1 geometry

This reuses Footprinter's existing `pin1location(side, alignment)` semantics and is intended for Core manufacturing metadata enrichment.

## Testing

- focused analyzer tests cover all rotations, reflected topology, ambiguity, and missing pin 1
- `bun run build`, including declaration generation
- CI full test and format suites
- manual cross-check against EasyEDA converter fixtures for DIP, SOIC, QFN, USB-C, and multi-row packages
