### PR TITLE
Add full names for asymmetric QFN pad parameters

### DIFF
--- a/src/fn/quad.ts
+++ b/src/fn/quad.ts
@@ -51,8 +51,14 @@ export const base_quad_def = base_def.extend({
   py: length.optional().describe("left and right side pad pitch"),
   pw: length.optional(),
   pl: length.optional(),
-  lrpw: length.optional().describe("left and right side pad width"),
-  lrpl: length.optional().describe("left and right side pad length"),
+  lrpw: length.optional().describe("alias for leftrightpadwidth"),
+  lrpl: length.optional().describe("alias for leftrightpadlength"),
+  leftrightpadwidth: length
+    .optional()
+    .describe("left and right side pad width"),
+  leftrightpadlength: length
+    .optional()
+    .describe("left and right side pad length"),
   thermalpad: z.union([z.literal(true), dim2d]).optional(),
   ...thermalPadOffsetFields,
   pillpads: z.boolean().optional().default(false),
@@ -62,6 +68,27 @@ export const base_quad_def = base_def.extend({
 export const quadTransform = <T extends z.infer<typeof base_quad_def>>(
   v: T,
 ) => {
+  if (
+    v.lrpw !== undefined &&
+    v.leftrightpadwidth !== undefined &&
+    v.lrpw !== v.leftrightpadwidth
+  ) {
+    throw new Error(
+      `Conflicting lrpw (${v.lrpw}) and leftrightpadwidth (${v.leftrightpadwidth})`,
+    )
+  }
+  if (
+    v.lrpl !== undefined &&
+    v.leftrightpadlength !== undefined &&
+    v.lrpl !== v.leftrightpadlength
+  ) {
+    throw new Error(
+      `Conflicting lrpl (${v.lrpl}) and leftrightpadlength (${v.leftrightpadlength})`,
+    )
+  }
+  v.leftrightpadwidth = v.leftrightpadwidth ?? v.lrpw
+  v.leftrightpadlength = v.leftrightpadlength ?? v.lrpl
+
   if (v.w && !v.h) {
     v.h = v.w
   } else if (!v.w && v.h) {
@@ -127,10 +154,21 @@ export const getQuadCoords = (params: {
   px?: number // horizontal pitch between top/bottom pins
   py?: number // vertical pitch between left/right pins
   pl: number // length of the pin
-  lrpl?: number // left and right side pin length
+  leftRightPadLength?: number
   legsoutside?: boolean
 }) => {
-  const { sidePinCounts, pn, w, h, p, px, py, pl, lrpl, legsoutside } = params
+  const {
+    sidePinCounts,
+    pn,
+    w,
+    h,
+    p,
+    px,
+    py,
+    pl,
+    leftRightPadLength,
+    legsoutside,
+  } = params
   const sidePinCountsCcw = [
     sidePinCounts.left,
     sidePinCounts.bottom,
@@ -149,7 +187,8 @@ export const getQuadCoords = (params: {
   const sidePinCount = sidePinCountsCcw[sideIndex]
   const side = SIDES_CCW[sideIndex]
   const sidePitch = side === "left" || side === "right" ? (py ?? p) : (px ?? p)
-  const padLength = side === "left" || side === "right" ? (lrpl ?? pl) : pl
+  const padLength =
+    side === "left" || side === "right" ? (leftRightPadLength ?? pl) : pl
 
   /** inner box width */
   const ibw = sidePitch * (sidePinCount - 1)
@@ -193,6 +232,10 @@ export const quad = (
   raw_params: z.input<typeof quad_def>,
 ): { circuitJson: AnyCircuitElement[]; parameters: any } => {
   const parameters = quad_def.parse(raw_params)
+  const leftRightPadWidth =
+    parameters.leftrightpadwidth ?? parameters.lrpw ?? parameters.pw
+  const leftRightPadLength =
+    parameters.leftrightpadlength ?? parameters.lrpl ?? parameters.pl
   const sidePinCounts = getQuadSidePinCounts(parameters)
   const pads: AnyCircuitElement[] = []
   let padOuterHalfX = 0
@@ -226,17 +269,13 @@ export const quad = (
       px: parameters.px,
       py: parameters.py,
       pl: parameters.pl,
-      lrpl: parameters.lrpl,
+      leftRightPadLength,
       legsoutside: parameters.legsoutside,
     })
 
     const isLeftOrRight = orientation === "vert"
-    let padWidth = isLeftOrRight
-      ? (parameters.lrpw ?? parameters.pw)
-      : parameters.pw
-    let padHeight = isLeftOrRight
-      ? (parameters.lrpl ?? parameters.pl)
-      : parameters.pl
+    let padWidth = isLeftOrRight ? leftRightPadWidth : parameters.pw
+    let padHeight = isLeftOrRight ? leftRightPadLength : parameters.pl
     if (orientation === "vert") {
       ;[padWidth, padHeight] = [padHeight, padWidth]
     }
@@ -263,7 +302,7 @@ export const quad = (
         parameters.pw
       const ibh =
         (parameters.py ?? parameters.p) * (verticalSidePinCount - 1) +
-        (parameters.lrpw ?? parameters.pw)
+        leftRightPadWidth
       padOuterHalfX = Math.max(
         padOuterHalfX,
         Math.abs(thermalPadOffset.x) + ibw / 2,
@@ -438,7 +477,7 @@ export const quad = (
     parameters.pw
   const pinRowSpanY =
     (verticalSidePinCount - 1) * (parameters.py ?? parameters.p) +
-    (parameters.lrpw ?? parameters.pw)
+    leftRightPadWidth
   const courtyardStepInnerHalfWidth = pinRowSpanX / 2 + 0.25
   const courtyardStepInnerHalfHeight = pinRowSpanY / 2 + 0.25
   const courtyardStepOuterHalfWidth = parameters.w / 2 + 0.25

--- a/src/footprinter.ts
+++ b/src/footprinter.ts
@@ -136,6 +136,8 @@ export type Footprinter = {
     | "pl"
     | "lrpw"
     | "lrpl"
+    | "leftrightpadwidth"
+    | "leftrightpadlength"
     | "leftpins"
     | "toppins"
     | "rightpins"

--- a/tests/qfn.test.ts
+++ b/tests/qfn.test.ts
@@ -139,6 +139,11 @@ test("qfn20 supports independently sized sides", () => {
 test("qfn10 supports wider left and right pads for C128396", () => {
   const soup = fp
     .string(
+      "qfn10_leftpins1_toppins4_rightpins1_bottompins4_px0.5mm_w2.4999864mm_h2.075264mm_pw0.2500122mm_pl0.5249926mm_leftrightpadwidth0.2999994mm_leftrightpadlength0.580009mm_rounded0",
+    )
+    .circuitJson()
+  const aliasSoup = fp
+    .string(
       "qfn10_leftpins1_toppins4_rightpins1_bottompins4_px0.5mm_w2.4999864mm_h2.075264mm_pw0.2500122mm_pl0.5249926mm_lrpw0.2999994mm_lrpl0.580009mm_rounded0",
     )
     .circuitJson()
@@ -157,6 +162,7 @@ test("qfn10 supports wider left and right pads for C128396", () => {
     height: 0.5249926,
   })
   expect(pads.every((pad) => pad.corner_radius === 0)).toBe(true)
+  expect(aliasSoup).toEqual(soup)
 
   expect(convertCircuitJsonToPcbSvg(soup)).toMatchSvgSnapshot(
     import.meta.path,


### PR DESCRIPTION
## Motivation

Follow-up to #769. The asymmetric QFN pad parameters were introduced only as the abbreviated `lrpw` and `lrpl` forms. Footprinter parameters should also provide descriptive full names while preserving the existing compact aliases.

## Implementation

- Add `leftrightpadwidth` as the full name for `lrpw`.
- Add `leftrightpadlength` as the full name for `lrpl`.
- Keep both abbreviated forms backward compatible.
- Reject conflicting values when both a full name and its alias are supplied.
- Use the full names as the canonical internal representation.
- Extend the C128396 QFN regression to verify that full names and aliases generate identical geometry.

## Validation

- `bun test tests/qfn.test.ts` — 6 passed
- `bun run build` — passed
