### PR TITLE
Add courtyards to all standard passives

### DIFF
--- a/src/helpers/passive-fn.ts
+++ b/src/helpers/passive-fn.ts
@@ -1,13 +1,13 @@
+import mm from "@tscircuit/mm"
 import type {
   AnyCircuitElement,
   PcbCourtyardRect,
   PcbSilkscreenPath,
 } from "circuit-json"
-import { rectpad } from "../helpers/rectpad"
-import mm from "@tscircuit/mm"
-import { platedhole } from "./platedhole"
+import { distance, length } from "circuit-json"
 import { z } from "zod"
-import { length, distance } from "circuit-json"
+import { rectpad } from "../helpers/rectpad"
+import { platedhole } from "./platedhole"
 import { type SilkscreenRef, silkscreenRef } from "./silkscreenRef"
 import { base_def } from "./zod/base_def"
 
@@ -19,8 +19,8 @@ type StandardSize = {
   pw_mm_min: number // pad width
   h_mm_min: number // body height
   w_mm_min: number // body width
-  courtyard_width_mm?: number
-  courtyard_height_mm?: number
+  courtyard_width_mm: number
+  courtyard_height_mm: number
   rounded_pads?: boolean
   nonpolarizedSilkscreen?: {
     line_half_length_mm?: number
@@ -50,6 +50,8 @@ export const footprintSizes: StandardSize[] = [
     ph_mm_min: 1.3,
     w_mm_min: 0.58,
     h_mm_min: 0.21,
+    courtyard_width_mm: 2.25,
+    courtyard_height_mm: 1.8,
   },
   {
     imperial: "1812",
@@ -342,10 +344,9 @@ export const passive = (params: PassiveDef): AnyCircuitElement[] => {
 
   const textY = textbottom ? -ph / 2 - 0.9 : ph / 2 + 0.9
   const silkscreenRefText: SilkscreenRef = silkscreenRef(0, textY, 0.2)
-  const courtyard =
-    sz?.courtyard_width_mm && sz.courtyard_height_mm
-      ? createCourtyardRect(sz.courtyard_width_mm, sz.courtyard_height_mm)
-      : null
+  const courtyard = sz
+    ? createCourtyardRect(sz.courtyard_width_mm, sz.courtyard_height_mm)
+    : null
   const shouldRoundPads = roundedPads ?? sz?.rounded_pads ?? false
   const cornerRadius = shouldRoundPads
     ? Math.min(0.125, Math.min(pw, ph) / 8)

--- a/tests/cap.test.ts
+++ b/tests/cap.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test"
+import { expect, test } from "bun:test"
 import { convertCircuitJsonToPcbSvg } from "circuit-to-svg"
 import { fp } from "../src/footprinter"
 
@@ -32,6 +32,12 @@ test("cap 0201", () => {
 
 test("cap 0504", () => {
   const soup = fp.string("0504").circuitJson()
+  const courtyard = soup.find(
+    (element) => element.type === "pcb_courtyard_rect",
+  )
+
+  expect(courtyard).toMatchObject({ width: 2.25, height: 1.8 })
+
   const svgContent = convertCircuitJsonToPcbSvg(soup)
   expect(svgContent).toMatchSvgSnapshot(import.meta.path, "cap_0504")
 })

--- a/tests/res.test.ts
+++ b/tests/res.test.ts
@@ -1,6 +1,14 @@
-import { test, expect } from "bun:test"
+import { expect, test } from "bun:test"
 import { convertCircuitJsonToPcbSvg } from "circuit-to-svg"
 import { fp } from "../src/footprinter"
+import { footprintSizes } from "../src/helpers/passive-fn"
+
+test("all standard passive sizes define courtyards", () => {
+  for (const size of footprintSizes) {
+    expect(size.courtyard_width_mm).toBeGreaterThan(0)
+    expect(size.courtyard_height_mm).toBeGreaterThan(0)
+  }
+})
 
 test("0402", () => {
   const soup = fp.string("0402").circuitJson()


### PR DESCRIPTION
## Summary

- add the missing courtyard for the 0504 / 1310 passive footprint
- require courtyard dimensions on every standard passive size
- add regression coverage for the complete standard-size table and the 0504 output

## Why

Standard resistor, capacitor, LED, and diode footprints share the passive size table. The 0504 / 1310 entry was the only standard size without courtyard dimensions, so footprints using that size omitted a courtyard.

The new 2.25 mm × 1.8 mm courtyard provides 0.25 mm clearance around the existing copper extents.

## Impact

All standard passive sizes now emit a courtyard. Custom parameter-only passive footprints keep their existing behavior and do not receive an implicit courtyard.

## Validation

- `bun test` — 387 passing
- `bun run build`
- `bunx biome check src/helpers/passive-fn.ts tests/res.test.ts tests/cap.test.ts`
- `git diff --check`