### PR TITLE
fix(solderjumper): default num_pins to 2 when omitted

### DIFF
--- a/src/fn/solderjumper.ts
+++ b/src/fn/solderjumper.ts
@@ -20,13 +20,13 @@ import { length } from "circuit-json"
  *   solderjumper({ num_pins: 3, pw: 2.0, ph: 1.0 }) // custom pad size
  */
 export const solderjumper = (params: {
-  num_pins: 2 | 3
+  num_pins?: 2 | 3
   bridged?: string
   p?: number
   pw?: number
   ph?: number
 }) => {
-  const { num_pins, bridged, p = 2.54, pw = 1.5, ph = 1.5 } = params
+  const { num_pins = 2, bridged, p = 2.54, pw = 1.5, ph = 1.5 } = params
   const padSpacing = length.parse(p)
   const padWidth = length.parse(pw)
   const padHeight = length.parse(ph)

--- a/tests/solderjumper-bare-string.test.ts
+++ b/tests/solderjumper-bare-string.test.ts
@@ -1,0 +1,22 @@
+import { test, expect } from "bun:test"
+import { fp } from "../src"
+
+test("solderjumper bare string defaults to 2 pins and emits finite geometry (#784)", () => {
+  const circuitJson = fp.string("solderjumper").circuitJson()
+
+  const smtpads = circuitJson.filter((e) => e.type === "pcb_smtpad")
+  expect(smtpads.length).toBe(2)
+
+  const courtyard = circuitJson.find((e) => e.type === "pcb_courtyard_rect") as any
+  expect(courtyard).toBeDefined()
+  expect(Number.isFinite(courtyard.width)).toBe(true)
+  expect(Number.isFinite(courtyard.height)).toBe(true)
+  expect(Number.isFinite(courtyard.center.x)).toBe(true)
+  expect(Number.isFinite(courtyard.center.y)).toBe(true)
+
+  const text = circuitJson.find((e) => e.type === "pcb_silkscreen_text") as any
+  if (text) {
+    expect(Number.isFinite(text.anchor_position.x)).toBe(true)
+    expect(Number.isFinite(text.anchor_position.y)).toBe(true)
+  }
+})


### PR DESCRIPTION
## Summary

Fixes #784.

Previously, \`solderjumper\` expected \`num_pins\` without a fallback default. When parsed via bare string \`fp.string("solderjumper")\`, \`num_pins\` was \`undefined\`, leading to \`NaN\` pad spacing, 0 pads, and \`NaN\` coordinates across courtyard and silkscreen elements.

### Changes
1. **Default Pin Count**: Made \`num_pins\` optional in \`solderjumper\` params and defaulted to \`2\`.
2. **Unit Tests**: Added \`tests/solderjumper-bare-string.test.ts\` verifying that bare string \`solderjumper\` emits 2 pads and finite courtyard/silkscreen geometry.

### Verification
- \`bun test tests/solderjumper-bare-string.test.ts\` (1/1 passing).
