### PR TITLE
fix(pad): default pad dimensions to 1mm when omitted

### DIFF
--- a/src/fn/pad.ts
+++ b/src/fn/pad.ts
@@ -20,9 +20,7 @@ export type PadDef = z.input<typeof pad_def>
 export const pad = (
   params: PadDef,
 ): { circuitJson: AnySoupElement[]; parameters: PadDef } => {
-  const width = mm(
-    params.w ?? params.width ?? params.s ?? params.size ?? "1mm",
-  )
+  const width = mm(params.w ?? params.width ?? params.s ?? params.size ?? "1mm")
   const height = mm(
     params.h ?? params.height ?? params.s ?? params.size ?? "1mm",
   )

--- a/src/fn/pad.ts
+++ b/src/fn/pad.ts
@@ -7,8 +7,12 @@ import { mm } from "@tscircuit/mm"
 import { base_def } from "../helpers/zod/base_def"
 
 export const pad_def = base_def.extend({
-  w: length,
-  h: length,
+  w: length.optional(),
+  h: length.optional(),
+  width: length.optional(),
+  height: length.optional(),
+  s: length.optional(),
+  size: length.optional(),
 })
 
 export type PadDef = z.input<typeof pad_def>
@@ -16,9 +20,12 @@ export type PadDef = z.input<typeof pad_def>
 export const pad = (
   params: PadDef,
 ): { circuitJson: AnySoupElement[]; parameters: PadDef } => {
-  const { w, h } = params
-  const width = mm(w)
-  const height = mm(h)
+  const width = mm(
+    params.w ?? params.width ?? params.s ?? params.size ?? "1mm",
+  )
+  const height = mm(
+    params.h ?? params.height ?? params.s ?? params.size ?? "1mm",
+  )
 
   return {
     circuitJson: [

--- a/tests/pad-bare-string.test.ts
+++ b/tests/pad-bare-string.test.ts
@@ -1,0 +1,20 @@
+import { test, expect } from "bun:test"
+import { fp } from "../src"
+
+test("pad bare string defaults to 1mm dimensions (#788)", () => {
+  const circuitJson = fp.string("pad").circuitJson()
+
+  const smtpads = circuitJson.filter((e) => e.type === "pcb_smtpad") as any[]
+  expect(smtpads.length).toBe(1)
+  expect(smtpads[0].width).toBe(1)
+  expect(smtpads[0].height).toBe(1)
+})
+
+test("pad with specified dimensions parses properly", () => {
+  const circuitJson = fp.string("pad_w2mm_h3mm").circuitJson()
+
+  const smtpads = circuitJson.filter((e) => e.type === "pcb_smtpad") as any[]
+  expect(smtpads.length).toBe(1)
+  expect(smtpads[0].width).toBe(2)
+  expect(smtpads[0].height).toBe(3)
+})


### PR DESCRIPTION
## Summary

Fixes #788.

Previously, \`pad_def\` required \`w\` and \`h\` without fallback defaults. When called by bare string \`fp.string("pad")\`, \`pad()\` forwarded \`undefined\` to \`mm(w)\`, throwing a raw internal \`TypeError\`.

### Changes
1. **Default Dimensions**: Made \`w\`, \`h\`, \`width\`, \`height\`, \`s\`, and \`size\` optional in \`pad_def\` and defaulted width/height to \`1mm\` in \`pad()\`, matching the behavior of \`smtpad\`.
2. **Unit Tests**: Added \`tests/pad-bare-string.test.ts\` verifying that bare string \`pad\` renders a 1mm pad without error.

### Verification
- \`bun test tests/pad-bare-string.test.ts\` (2/2 passing).
