### PR TITLE
fix(fpc): default num_pins to 12 when called by bare string

### DIFF
--- a/src/fn/fpc.ts
+++ b/src/fn/fpc.ts
@@ -11,7 +11,7 @@ import { base_def } from "../helpers/zod/base_def"
 
 export const fpc_def = base_def.extend({
   fn: z.literal("fpc"),
-  num_pins: z.coerce.number().int().min(2),
+  num_pins: z.coerce.number().int().min(2).default(12),
   p: length.default("0.5mm").describe("contact pad pitch"),
   pw: length.default("0.3mm").describe("contact pad width"),
   pl: length.default("1.25mm").describe("contact pad length"),

--- a/tests/fpc-bare-string.test.ts
+++ b/tests/fpc-bare-string.test.ts
@@ -1,0 +1,18 @@
+import { test, expect } from "bun:test"
+import { fp } from "../src"
+
+test("fpc bare string defaults to 12 pins without throwing (#786)", () => {
+  const circuitJson = fp.string("fpc").circuitJson()
+
+  const smtpads = circuitJson.filter((e) => e.type === "pcb_smtpad")
+  // 12 contact pads + 2 mounting pads = 14 pads
+  expect(smtpads.length).toBe(14)
+})
+
+test("fpc with explicit pin count parses correctly", () => {
+  const circuitJson = fp.string("fpc6").circuitJson()
+
+  const smtpads = circuitJson.filter((e) => e.type === "pcb_smtpad")
+  // 6 contact pads + 2 mounting pads = 8 pads
+  expect(smtpads.length).toBe(8)
+})


### PR DESCRIPTION
## Summary

Fixes #786.

Previously, \`fpc_def\` did not provide a default for \`num_pins\`. When called by bare string \`fp.string("fpc")\`, \`num_pins\` was \`undefined\` and coerced to \`NaN\`, throwing a raw Zod parse error.

### Changes
1. **Default Pin Count**: Added \`.default(12)\` to \`num_pins\` in \`fpc_def\`, matching the standard 12-pin layout (FPC-05F-12PH20).
2. **Unit Tests**: Added \`tests/fpc-bare-string.test.ts\` verifying that bare string \`fpc\` renders 14 pads (12 signal pins + 2 mounting pads) without error.

### Verification
- \`bun test tests/fpc-bare-string.test.ts\` (2/2 passing).
