### PR TITLE
fix(vson): add standard default dimensions to vson_def

### DIFF
--- a/src/fn/vson.ts
+++ b/src/fn/vson.ts
@@ -15,7 +15,9 @@ import { createRectUnionOutline } from "src/helpers/rect-union-outline"
 export const vson_def = base_def.extend({
   fn: z.string(),
   num_pins: z.number().optional().default(8),
-  p: distance.default("0.5mm").describe("pitch (distance between center of each pin)"),
+  p: distance
+    .default("0.5mm")
+    .describe("pitch (distance between center of each pin)"),
   w: length.default("3.3mm").describe("width between vertical rows of pins"),
   grid: dim2d
     .default("3x3mm")

--- a/src/fn/vson.ts
+++ b/src/fn/vson.ts
@@ -12,21 +12,22 @@ import { dim2d } from "src/helpers/zod/dim-2d"
 import { type SilkscreenRef, silkscreenRef } from "src/helpers/silkscreenRef"
 import { createRectUnionOutline } from "src/helpers/rect-union-outline"
 
-// can't use defaults because there is not a lot of common dimensions.
 export const vson_def = base_def.extend({
   fn: z.string(),
   num_pins: z.number().optional().default(8),
-  p: distance.describe("pitch (distance between center of each pin)"),
-  w: length.describe("width between vertical rows of pins"),
-  grid: dim2d.describe("width and height of the border of the footprint"),
+  p: distance.default("0.5mm").describe("pitch (distance between center of each pin)"),
+  w: length.default("3.3mm").describe("width between vertical rows of pins"),
+  grid: dim2d
+    .default("3x3mm")
+    .describe("width and height of the border of the footprint"),
   ep: dim2d
     .default("0x0mm")
     .describe("width and height of the central exposed thermal pad"),
   epx: length
     .default("0mm")
     .describe("x offset of the center of the central exposed thermal pad"),
-  pinw: length.describe("width of the pin pads"),
-  pinh: length.describe("height of the pin pads"),
+  pinw: length.default("0.6mm").describe("width of the pin pads"),
+  pinh: length.default("0.24mm").describe("height of the pin pads"),
 })
 
 export type VsonDefInput = z.input<typeof vson_def>

--- a/tests/vson-bare-string.test.ts
+++ b/tests/vson-bare-string.test.ts
@@ -1,0 +1,16 @@
+import { test, expect } from "bun:test"
+import { fp } from "../src"
+
+test("vson8 bare string renders 8 pads without throwing (#782)", () => {
+  const circuitJson = fp.string("vson8").circuitJson()
+
+  const smtpads = circuitJson.filter((e) => e.type === "pcb_smtpad")
+  expect(smtpads.length).toBe(8)
+})
+
+test("vson bare string defaults to 8 pads", () => {
+  const circuitJson = fp.string("vson").circuitJson()
+
+  const smtpads = circuitJson.filter((e) => e.type === "pcb_smtpad")
+  expect(smtpads.length).toBe(8)
+})


### PR DESCRIPTION
## Summary

Fixes #782.

Previously, \`vson_def\` declared \`p\`, \`w\`, \`grid\`, \`pinw\`, and \`pinh\` without default values. Calling \`fp.string("vson8")\` failed with a raw Zod parse error.

### Changes
1. **Default Dimensions**: Added standard package default dimensions to \`vson_def\` (\`p: "0.5mm"\`, \`w: "3.3mm"\`, \`grid: "3x3mm"\`, \`pinw: "0.6mm"\`, \`pinh: "0.24mm"\`), matching sibling \`son\` and \`wson\` footprint behavior.
2. **Unit Tests**: Added \`tests/vson-bare-string.test.ts\` verifying that bare string \`vson8\` and \`vson\` render 8 pads without error.

### Verification
- \`bun test tests/vson-bare-string.test.ts\` (2/2 passing).
