### PR TITLE
fix(lcc): default pitch to standard 1.27mm to eliminate overlapping pads

### DIFF
--- a/src/fn/lcc.ts
+++ b/src/fn/lcc.ts
@@ -8,6 +8,9 @@ export const lcc = (
   parameters: z.input<typeof lcc_def>,
 ): { circuitJson: AnySoupElement[]; parameters: any } => {
   parameters.legsoutside = false
+  if (!parameters.p) {
+    parameters.p = 1.27
+  }
   if (!parameters.pl) {
     parameters.pl = 1.0
   }

--- a/tests/lcc-pitch.test.ts
+++ b/tests/lcc-pitch.test.ts
@@ -1,0 +1,22 @@
+import { test, expect } from "bun:test"
+import { fp } from "../src/index"
+
+test("lcc defaults to standard 1.27mm pitch without overlapping pads (#794)", () => {
+  const elements = fp.string("lcc44").circuitJson()
+  const smtpads = elements.filter(
+    (e: any) => e.type === "pcb_smtpad",
+  ) as Array<any>
+
+  expect(smtpads.length).toBe(44)
+
+  // Pin 1 and Pin 2 on the left side
+  const pin1 = smtpads.find((p) => p.port_hints?.includes("1"))!
+  const pin2 = smtpads.find((p) => p.port_hints?.includes("2"))!
+
+  expect(pin1).toBeDefined()
+  expect(pin2).toBeDefined()
+
+  const pitch = Math.abs(pin1.y - pin2.y)
+  expect(pitch).toBeCloseTo(1.27, 2)
+  expect(pin1.height).toBeLessThanOrEqual(pitch)
+})


### PR DESCRIPTION
## Summary

Fixes #794.

Previously, calling \`fp.string("lccN")\` without an explicit pitch inherited the generic quad default pitch of \`0.5mm\`. Because LCC pad width (\`pw\`) defaults to \`0.6mm\`, adjacent pads overlapped by \`0.1mm\`, generating an electrical short on emitted PCBs.

### Changes
1. **Default Pitch**: Defaulted \`parameters.p\` to standard \`1.27mm\` (JEDEC MO-047 / MS-034 standard for LCC/PLCC packages) in \`src/fn/lcc.ts\` when not explicitly specified by the caller.
2. **Unit Tests**: Added \`tests/lcc-pitch.test.ts\` asserting that \`fp.string("lcc44")\` pads have \`1.27mm\` pitch spacing and do not overlap.

### Verification
- \`bun test tests/lcc-pitch.test.ts\` (1/1 passing).
