### PR TITLE
fix(tqfp44): default pitch to 0.8mm and pad width to 0.55mm

### DIFF
--- a/src/fn/tqfp.ts
+++ b/src/fn/tqfp.ts
@@ -14,9 +14,9 @@ export const tqfp = (
   if (!raw_params.p) {
     switch (raw_params.num_pins) {
       case 32:
+      case 44:
         raw_params.p = 0.8
         break
-      case 44:
       case 48:
         raw_params.p = 0.5
         break
@@ -54,9 +54,9 @@ export const tqfp = (
   if (!raw_params.pw) {
     switch (raw_params.num_pins) {
       case 32:
+      case 44:
         raw_params.pw = 0.55
         break
-      case 44:
       case 48:
       case 64:
       case 80:

--- a/tests/tqfp44-pitch.test.ts
+++ b/tests/tqfp44-pitch.test.ts
@@ -1,0 +1,22 @@
+import { test, expect } from "bun:test"
+import { fp } from "../src/index"
+
+test("tqfp44 defaults to standard 0.8mm pitch and 0.55mm pad width (#792)", () => {
+  const elements = fp.string("tqfp44").circuitJson()
+  const smtpads = elements.filter(
+    (e: any) => e.type === "pcb_smtpad",
+  ) as Array<any>
+
+  expect(smtpads.length).toBe(44)
+
+  const pin1 = smtpads.find((p) => p.port_hints?.includes("1"))!
+  const pin2 = smtpads.find((p) => p.port_hints?.includes("2"))!
+
+  expect(pin1).toBeDefined()
+  expect(pin2).toBeDefined()
+
+  const pitch = Math.abs(pin1.y - pin2.y)
+  expect(pitch).toBeCloseTo(0.8, 2)
+  expect(pin1.height).toBeCloseTo(0.55, 2)
+  expect(pin1.width).toBeCloseTo(1.475, 2)
+})


### PR DESCRIPTION
## Summary

Fixes #792.

Previously, \`fp.string("tqfp44")\` was grouped with 48/64/100 pin packages in \`src/fn/tqfp.ts\`, producing a 44-pin QFP on a \`0.5mm\` pitch with \`0.30mm\`-wide pads. Standard TQFP-44 (JEDEC MS-026 BBA / KiCad \`TQFP-44_10x10mm_P0.8mm\`) is a 10x10mm body on a \`0.8mm\` pitch with \`0.55mm\` pad width.

### Changes
1. **Pitch & Pad Width Defaults**: Grouped \`case 44\` with \`case 32\` in \`src/fn/tqfp.ts\` to default pitch to \`0.8mm\` and pad width to \`0.55mm\`.
2. **Unit Tests**: Added \`tests/tqfp44-pitch.test.ts\` verifying that \`fp.string("tqfp44")\` emits pads with 0.8mm pitch spacing and 0.55mm pad width.

### Verification
- \`bun test tests/tqfp44-pitch.test.ts\` (1/1 passing).
