### PR TITLE
fix(sot23): add silkscreen body outline and pin 1 marker for 3-pin variant

### DIFF
--- a/src/fn/sot23.ts
+++ b/src/fn/sot23.ts
@@ -146,6 +146,55 @@ export const sot23_3 = (parameters: z.infer<typeof sot23_def>) => {
     0.3,
   )
 
+  const width = w / 2 - pl / 2
+  const height = h / 2
+  const silkscreenPath1: PcbSilkscreenPath = {
+    layer: "top",
+    pcb_component_id: "",
+    pcb_silkscreen_path_id: "silkscreen_path_1",
+    route: [
+      { x: -width, y: height },
+      { x: width + 0.2, y: height },
+      { x: width + 0.2, y: height / 2 },
+    ],
+    type: "pcb_silkscreen_path",
+    stroke_width: 0.1,
+  }
+  const silkscreenPath2: PcbSilkscreenPath = {
+    layer: "top",
+    pcb_component_id: "",
+    pcb_silkscreen_path_id: "silkscreen_path_2",
+    route: [
+      { x: -width, y: -height },
+      { x: width + 0.2, y: -height },
+      { x: width + 0.2, y: -height / 2 },
+    ],
+    type: "pcb_silkscreen_path",
+    stroke_width: 0.1,
+  }
+
+  const pin1Position = getCcwSot23Coords({
+    num_pins: parameters.num_pins,
+    pn: 1,
+    w,
+    h,
+    pl,
+    p,
+  })
+  const pin1Indicator: PcbSilkscreenPath = {
+    type: "pcb_silkscreen_path",
+    layer: "top",
+    pcb_component_id: "",
+    pcb_silkscreen_path_id: "pin1_indicator",
+    route: [
+      { x: pin1Position.x - pl / 2 - 0.2, y: pin1Position.y + 0.15 },
+      { x: pin1Position.x - pl / 2 - 0.5, y: pin1Position.y },
+      { x: pin1Position.x - pl / 2 - 0.2, y: pin1Position.y - 0.15 },
+      { x: pin1Position.x - pl / 2 - 0.2, y: pin1Position.y + 0.15 },
+    ],
+    stroke_width: 0.05,
+  }
+
   const courtyard: PcbCourtyardOutline = {
     type: "pcb_courtyard_outline",
     pcb_courtyard_outline_id: "",
@@ -154,7 +203,14 @@ export const sot23_3 = (parameters: z.infer<typeof sot23_def>) => {
     layer: "top",
   }
 
-  return [...pads, silkscreenRefText as AnyCircuitElement, courtyard]
+  return [
+    ...pads,
+    silkscreenPath1,
+    silkscreenPath2,
+    pin1Indicator as AnyCircuitElement,
+    silkscreenRefText as AnyCircuitElement,
+    courtyard,
+  ]
 }
 
 export const getCcwSot235Coords = (parameters: {

--- a/tests/sot23-silkscreen.test.ts
+++ b/tests/sot23-silkscreen.test.ts
@@ -1,0 +1,18 @@
+import { test, expect } from "bun:test"
+import { fp } from "../src/index"
+
+test("sot23 (3-pin) generates silkscreen body outline and pin 1 indicator (#732)", () => {
+  const elements = fp.string("sot23").circuitJson()
+
+  const silkscreenPaths = elements.filter(
+    (e: any) => e.type === "pcb_silkscreen_path",
+  ) as Array<any>
+
+  expect(silkscreenPaths.length).toBeGreaterThanOrEqual(3)
+
+  const pin1Indicator = silkscreenPaths.find(
+    (p) => p.pcb_silkscreen_path_id === "pin1_indicator",
+  )
+  expect(pin1Indicator).toBeDefined()
+  expect(pin1Indicator.route.length).toBe(4)
+})


### PR DESCRIPTION
## Summary

Fixes #732.

Previously, \`fp.string("sot23")\` (the standard 3-pin variant) emitted no silkscreen body outline or pin 1 marker, leaving the physical component boundaries and orientation ambiguous on emitted boards.

### Changes
1. **Silkscreen Paths & Pin 1 Indicator**: Added top and bottom silkscreen body segment paths and a triangular pin 1 marker to \`sot23_3()\` in \`src/fn/sot23.ts\`, matching sibling SOT footprints (\`sot23_5\`, \`sot23w\`, \`sot323\`).
2. **Unit Tests**: Added \`tests/sot23-silkscreen.test.ts\` verifying that \`sot23\` emits silkscreen body paths and the \`pin1_indicator\` path.

### Verification
- \`bun test tests/sot23-silkscreen.test.ts\` (1/1 passing).
