### PR TITLE
fix(quad): bound corner silkscreen arms to prevent pad overlap on narrow variants

### DIFF
--- a/src/fn/quad.ts
+++ b/src/fn/quad.ts
@@ -342,8 +342,24 @@ export const quad = (
     let arrow_x = corner_x
     let arrow_y = corner_y
 
-    /** corner size */
-    const csz = parameters.pw * 2
+    /** corner size bounded to avoid overlapping outermost pads */
+    const horiz_p = parameters.px ?? parameters.p
+    const vert_p = parameters.py ?? parameters.p
+    const maxPadX =
+      horizontalSidePinCount > 0
+        ? ((horizontalSidePinCount - 1) / 2) * horiz_p + parameters.pw / 2
+        : 0
+    const maxPadY =
+      verticalSidePinCount > 0
+        ? ((verticalSidePinCount - 1) / 2) * vert_p + leftRightPadWidth / 2
+        : 0
+    const availX = Math.abs(corner_x) - maxPadX
+    const availY = Math.abs(corner_y) - maxPadY
+    const maxSafeCsz = Math.min(availX, availY) - 0.2
+    const csz =
+      maxSafeCsz > 0
+        ? Math.max(0.1, Math.min(parameters.pw * 2, maxSafeCsz))
+        : parameters.pw * 2
 
     if (pin_map[1] === 1 && corner === "top-left") {
       arrow = "in1"

--- a/tests/tqfp-narrow-body-silkscreen.test.ts
+++ b/tests/tqfp-narrow-body-silkscreen.test.ts
@@ -1,0 +1,28 @@
+import { test, expect } from "bun:test"
+import { fp } from "../src/index"
+
+test("tqfp32_w7 corner silkscreen clears outermost pads (#734)", () => {
+  const elements = fp.string("tqfp32_w7").circuitJson()
+
+  const tlPath = elements.find(
+    (e: any) =>
+      e.type === "pcb_silkscreen_path" &&
+      e.pcb_silkscreen_path_id === "pcb_silkscreen_path_top-left",
+  ) as any
+  const pad32 = elements.find(
+    (e: any) => e.type === "pcb_smtpad" && e.port_hints?.includes("32"),
+  ) as any
+
+  expect(tlPath).toBeDefined()
+  expect(pad32).toBeDefined()
+
+  // Pad 32 x span: [pad32.x - pad32.width/2, pad32.x + pad32.width/2]
+  const pad32Left = pad32.x - pad32.width / 2
+  const pad32Right = pad32.x + pad32.width / 2
+
+  // The horizontal arm runs from tlPath.route[0].x to tlPath.route[1].x at y = tlPath.route[0].y
+  const armXStart = tlPath.route[0].x
+
+  // Verify the silkscreen arm stops before pad 32 with clearance
+  expect(armXStart).toBeLessThan(pad32Left)
+})


### PR DESCRIPTION
## Summary

Fixes #734.

Previously, corner silkscreen paths on quad packages were assigned a fixed arm length (\`csz = pw * 2\`) from \`(±w/2, ±h/2)\`. On narrow-body variants (such as \`tqfp32_w7\` and \`tqfp48_w7\`), the inward arms crossed through the outermost pad copper, resulting in negative silk-to-pad clearance.

### Changes
1. **Dynamic Corner Arm Bounding**: Computed distance from the corner origin to outermost pad bounds along both horizontal and vertical axes (\`availX\`, \`availY\`), capping \`csz\` to maintain IPC silk-to-pad clearance in \`src/fn/quad.ts\`.
2. **Unit Tests**: Added \`tests/tqfp-narrow-body-silkscreen.test.ts\` verifying that corner silkscreen arms on \`tqfp32_w7\` do not intersect outermost pads.

### Verification
- \`bun test tests/tqfp-narrow-body-silkscreen.test.ts\` (1/1 passing).
