### PR TITLE
Say what `invert` and `faceup` mean, and deprecate `faceup`

### DIFF
--- a/src/helpers/zod/base_def.ts
+++ b/src/helpers/zod/base_def.ts
@@ -10,11 +10,15 @@ export const base_def = z.object({
   invert: z
     .boolean()
     .optional()
-    .describe("hint to invert the orientation of the 3D model"),
+    .describe(
+      "install the part backwards: for a pin header, the LONG pins pass through the board instead of the short ones. It does not change which side of the board the part is on — that is the component's `layer`",
+    ),
   faceup: z
     .boolean()
     .optional()
-    .describe("The male pin header should face upwards, out of the top layer"),
+    .describe(
+      "DEPRECATED, and a no-op for through-hole parts. It meant 'the male pin header should face upwards, out of the top layer', which is what a correctly mounted header does by default; its other effect was to delete the pins below the board, leaving a through-hole part that cannot be soldered into its own plated holes. Use `layer` for which side of the board a part is on, and `invert` to install it backwards",
+    ),
   nosilkscreen: z
     .boolean()
     .optional()


### PR DESCRIPTION
Both are 3D-model hints on every footprint, and neither said enough to be
used correctly. Nothing in the ecosystem sets either one — the only
references anywhere are this schema and jscad-electronics' own examples —
so the descriptions were the whole specification, and they were wrong about
the one thing that matters.

`invert` said "hint to invert the orientation of the 3D model", which reads
as "flip it over" and so as a way to mount a part on the underside of the
board. It is not: which side a part is on is the component's `layer`, and
consumers implement that themselves (3d-viewer moves a bottom-layer part to
-(z + pcbThickness) and rotates it 180 degrees about X). A model that also
flipped itself would be flipped twice. What `invert` actually selects, and
what it selected when it was added, is which END of the pins passes through
the board: installed backwards, a header puts its LONG pins through.

`faceup` is deprecated. It was added a day after `invert`, sharing its
expression, and its only distinct effect was deleting the pins below the
board. On a through-hole footprint — which is plated HOLES — that produces a
part that cannot be soldered into its own land pattern, and the orientation
it described ("should face upwards, out of the top layer") is what a
correctly mounted header does by default.

Descriptions only; no behaviour changes here. jscad-electronics has been
made to match in tscircuit/jscad-electronics#333.

<!-- tsc-dev-pr-stack:start -->
## Merge stack

Stack: `pin-header-semantics` · layer `flags`
Upstream branch: `footprinter:fix/clarify-pinrow-orientation-flags`
Base: `main`

Prerequisites: none

Managed by `./tsc-dev pr-stack`; edit prose above this block freely.
<!-- tsc-dev-pr-stack:end -->
