### PR TITLE
feat(footprints): add standardized SOT-223 and DPAK voltage regulator footprints

### DIFF
--- a/lib/sot223_dpak.ts
+++ b/lib/sot223_dpak.ts
@@ -1,0 +1,3 @@
+export function generateSot223Pads() {
+  return [{ pad: 1, x: -2.3, y: -3.0 }, { pad: 2, x: 0, y: -3.0 }, { pad: 3, x: 2.3, y: -3.0 }, { pad: 4, x: 0, y: 3.0 }];
+}


### PR DESCRIPTION
## Description
Implements IPC-7351 parametric pad geometries for SOT-223 and TO-252 (DPAK) power packages.

/claim