### PR TITLE
fix(solderjumper): default num_pins to 2 when omitted to prevent NaN geometry

### DIFF
--- a/src/fn/solderjumper.ts
+++ b/src/fn/solderjumper.ts
@@ -20,13 +20,13 @@ import { length } from "circuit-json"
  *   solderjumper({ num_pins: 3, pw: 2.0, ph: 1.0 }) // custom pad size
  */
 export const solderjumper = (params: {
-  num_pins: 2 | 3
+  num_pins?: 2 | 3
   bridged?: string
   p?: number
   pw?: number
   ph?: number
 }) => {
-  const { num_pins, bridged, p = 2.54, pw = 1.5, ph = 1.5 } = params
+  const { num_pins = 2, bridged, p = 2.54, pw = 1.5, ph = 1.5 } = params
   const padSpacing = length.parse(p)
   const padWidth = length.parse(pw)
   const padHeight = length.parse(ph)

--- a/tests/solderjumper.test.ts
+++ b/tests/solderjumper.test.ts
@@ -86,3 +86,19 @@ test("solderjumper 2-pin custom pad size", () => {
     "solderjumper2bridged12pw2ph0.5",
   )
 })
+
+test("bare solderjumper without pin count defaults to 2 pins without NaN", () => {
+  const circuitJson = fp.string("solderjumper").circuitJson()
+  const pads = circuitJson.filter((e) => e.type === "pcb_smtpad")
+  expect(pads.length).toBe(2)
+
+  const courtyard = circuitJson.find((e) => e.type === "pcb_courtyard_rect") as any
+  expect(courtyard).toBeDefined()
+  expect(Number.isNaN(courtyard.width)).toBe(false)
+  expect(Number.isNaN(courtyard.center.x)).toBe(false)
+
+  const text = circuitJson.find((e) => e.type === "pcb_silkscreen_text") as any
+  if (text && text.anchor_position) {
+    expect(Number.isNaN(text.anchor_position.x)).toBe(false)
+  }
+})

--- a/tests/solderjumper.test.ts
+++ b/tests/solderjumper.test.ts
@@ -92,7 +92,9 @@ test("bare solderjumper without pin count defaults to 2 pins without NaN", () =>
   const pads = circuitJson.filter((e) => e.type === "pcb_smtpad")
   expect(pads.length).toBe(2)
 
-  const courtyard = circuitJson.find((e) => e.type === "pcb_courtyard_rect") as any
+  const courtyard = circuitJson.find(
+    (e) => e.type === "pcb_courtyard_rect",
+  ) as any
   expect(courtyard).toBeDefined()
   expect(Number.isNaN(courtyard.width)).toBe(false)
   expect(Number.isNaN(courtyard.center.x)).toBe(false)


### PR DESCRIPTION
Fixes #784

## Summary
- Defaults `num_pins` to `2` in `src/fn/solderjumper.ts` so calling `fp.string("solderjumper")` without an explicit pin count renders a valid 2-pin footprint instead of emitting `NaN` geometry / 0 pads.
- Added unit test in `tests/solderjumper.test.ts` verifying bare string call produces 2 pads with finite courtyard and silkscreen coordinates.

## Verification
```bash
bun test tests/solderjumper.test.ts
# 6 pass, 0 fail
```

/claim #784
