### PR TITLE
feat(to92): add inline pitch parameter for perfboard compatibility (#4426)

### DIFF
--- a/src/fn/to92.ts
+++ b/src/fn/to92.ts
@@ -30,6 +30,13 @@ export const to92_def = base_def.extend({
   string: z.string().optional(),
 })
 
+// Parámetro de pitch para modo inline (permite separación estándar de perfboard).
+// Por defecto respeta el pitch de KiCad (1.27mm) para mantener paridad.
+const extractInlinePitch = (str?: string): number | null => {
+  const m = str?.match(/_pitch([\d.]+)mm/i)
+  return m ? Number.parseFloat(m[1]) : null
+}
+
 const generateSemicircle = (
   centerX: number,
   centerY: number,
@@ -76,9 +83,12 @@ export const to92 = (
     num_pins: numPins,
   })
 
-  const { p, id, od, w, h, inline } = parameters
+  const { p, id, od, w, h, inline, string } = parameters
   const holeY = Number.parseFloat(h) / 2
-  const padSpacing = Number.parseFloat(p)
+  const inlinePitch = extractInlinePitch(string)
+  const padSpacing = inline
+    ? (inlinePitch ?? Number.parseFloat(p))
+    : Number.parseFloat(p)
   const holeDia = Number.parseFloat(id)
   const padDia = Number.parseFloat(od)
 

--- a/tests/to92-pitch.test.ts
+++ b/tests/to92-pitch.test.ts
@@ -1,0 +1,13 @@
+import { test, expect } from "bun:test"
+import { fp } from "../src/footprinter"
+
+test("to92_inline_pitch2.54mm aligns holes for perfboard", () => {
+  const cj = fp.string("to92_inline_pitch2.54mm").circuitJson()
+  const holes = cj
+    .filter((e: any) => e.type === "pcb_plated_hole")
+    .map((h: any) => ({ x: h.x, y: h.y }))
+  // Los 3 agujeros deben estar en linea recta (misma y) separados 2.54mm
+  expect(holes[0].y).toBeCloseTo(holes[1].y, 5)
+  expect(holes[1].y).toBeCloseTo(holes[2].y, 5)
+  expect(holes[2].x - holes[0].x).toBeCloseTo(5.08, 2) // 2 * 2.54
+})


### PR DESCRIPTION
## Summary

Fixes tscircuit/tscircuit#4426 — TO-92 footprints don't fit standard 2.54mm perfboard.

**Root cause**: `to92_inline` always used the KiCad default pitch (1.27mm), leaving the three holes in a narrow row that doesn't match breadboard/perfboard spacing.

**Change**: added an optional `_pitchXXmm` suffix to the inline variant (e.g. `to92_inline_pitch2.54mm`) that aligns all three holes in a straight line with the requested spacing. The default inline pitch (1.27mm) is unchanged, so KiCad parity is preserved.

**Verified**:
- `to92` (triangular) geometry unchanged
- `to92_inline` KiCad parity test still passes
- New `to92_inline_pitch2.54mm` produces 3 holes in a line, 5.08mm total span (2×2.54mm)
- Full suite: 563 pass (2 pre-existing sot363 parity failures unrelated to this change)

Usage for the issue reporter:
```tsx
<footprint to92_inline_pitch2.54mm />
```
