### PR TITLE
fix: default LCC pitch to 1.27mm so pads do not overlap

### DIFF
--- a/src/fn/lcc.ts
+++ b/src/fn/lcc.ts
@@ -8,6 +8,11 @@ export const lcc = (
   parameters: z.input<typeof lcc_def>,
 ): { circuitJson: AnySoupElement[]; parameters: any } => {
   parameters.legsoutside = false
+  // Standard LCC/PLCC lead pitch is 1.27mm; quad's 0.5mm default leaves
+  // 0.6mm-wide pads overlapping by 0.1mm along the column.
+  if (!parameters.p) {
+    parameters.p = 1.27
+  }
   if (!parameters.pl) {
     parameters.pl = 1.0
   }

--- a/tests/lcc.test.ts
+++ b/tests/lcc.test.ts
@@ -11,3 +11,37 @@ test("lcc68", () => {
 
   expect(svgContent).toMatchSvgSnapshot(import.meta.path, "lcc68")
 })
+
+test("lcc pads do not overlap along the pitch axis", () => {
+  for (const name of ["lcc20", "lcc44"]) {
+    const pads = fp
+      .string(name)
+      .circuitJson()
+      .filter((el: any) => el.type === "pcb_smtpad") as any[]
+
+    const maxX = Math.max(...pads.map((p) => p.x))
+    const colPads = pads.filter((p) => Math.abs(p.x - maxX) < 0.01)
+    const col = colPads.map((p) => p.y).sort((a: number, b: number) => b - a)
+    const maxExtent = Math.max(...colPads.map((p) => p.height))
+
+    for (let i = 1; i < col.length; i++) {
+      expect(
+        col[i - 1] - col[i],
+        `${name}: adjacent pads overlap`,
+      ).toBeGreaterThanOrEqual(maxExtent)
+    }
+  }
+})
+
+test("lcc default pitch is 1.27mm", () => {
+  const pads = fp
+    .string("lcc44")
+    .circuitJson()
+    .filter((el: any) => el.type === "pcb_smtpad") as any[]
+  const maxX = Math.max(...pads.map((p) => p.x))
+  const col = pads
+    .filter((p) => Math.abs(p.x - maxX) < 0.01)
+    .map((p) => p.y)
+    .sort((a: number, b: number) => b - a)
+  expect(Math.round((col[0] - col[1]) * 1000) / 1000).toBe(1.27)
+})


### PR DESCRIPTION
Fixes #794

## What

`lcc` inherited quad's 0.5mm default pitch while defaulting pad width to 0.6mm, so adjacent pads in each column overlapped by 0.1mm — a short in the emitted PCB (reproduced: lcc44 right-column ys at 2.5/2.0/1.5 with 0.6mm pads).

LCC/PLCC lead pitch is **1.27mm**, so `lcc` now defaults `p` to 1.27mm; an explicit `p` override still wins. After the fix the column reads 6.35/5.08/3.81 with 0.67mm clearance.

## Verification

- Repro before: gaps [0.5] with 0.6mm pads → overlap; after: gaps [1.27]
- New regression tests: no adjacent-pad overlap for `lcc20` and `lcc44`, and exact 1.27mm default pitch
- Full suite: 566/566 pass, biome clean