### PR TITLE
fix: sot723 numbers pins per the Toshiba datasheet

### DIFF
--- a/src/fn/sot723.ts
+++ b/src/fn/sot723.ts
@@ -60,13 +60,16 @@ export const getCcwSot723Coords = (parameters: {
 }) => {
   const { pn, w, h, pl, p } = parameters
 
+  // Per the Toshiba SOT-723 datasheet (and KiCad's SOT-723 footprint),
+  // pin 1 is the top-left pad, pin 2 bottom-left, and pin 3 sits alone on
+  // the right — the previous mapping swapped pins 1 and 3.
   if (pn === 1) {
-    return { x: p, y: 0 }
+    return { x: -p, y: 0.4 }
   }
   if (pn === 2) {
     return { x: -p, y: -0.4 }
   }
-  return { x: -p, y: 0.4 }
+  return { x: p, y: 0 }
 }
 
 export const sot723WithoutParsing = (

--- a/tests/sot723-pin-order.test.ts
+++ b/tests/sot723-pin-order.test.ts
@@ -1,0 +1,16 @@
+import { test, expect } from "bun:test"
+import { fp } from "src/footprinter"
+
+test("sot723 numbers pins per the Toshiba datasheet (#686)", () => {
+  const circuitJson = fp.string("sot723").circuitJson()
+  const pads = circuitJson.filter(
+    (el: any) => el.type === "pcb_smtpad",
+  ) as any[]
+
+  const byPin = (n: string) =>
+    pads.find((p) => (p.port_hints ?? []).includes(n))
+
+  expect(byPin("1")).toMatchObject({ x: -0.575, y: 0.4 })
+  expect(byPin("2")).toMatchObject({ x: -0.575, y: -0.4 })
+  expect(byPin("3")).toMatchObject({ x: 0.575, y: 0 })
+})


### PR DESCRIPTION
Fixes #686

## What

`getCcwSot723Coords` mapped pin 1 to the lone right pad `(0.575, 0)` and pin 3 to top-left — the reverse of the Toshiba SOT-723 datasheet and KiCad's `SOT-723` footprint. A real part would be misnumbered/mirrored on the assembled PCB.

Swapped so:
- pin 1 → `(-0.575, +0.4)` (top-left)
- pin 2 → `(-0.575, -0.4)` (bottom-left, unchanged)
- pin 3 → `(0.575, 0)` (alone on the right)

## Verification

- Repro confirms the new positions exactly
- Regression test `tests/sot723-pin-order.test.ts` asserts each pin's coordinates; SVG snapshots updated; full suite 565/565 pass, biome clean