### PR TITLE
fix: msop and son number right-column pins counter-clockwise

### DIFF
--- a/src/fn/msop.ts
+++ b/src/fn/msop.ts
@@ -103,7 +103,11 @@ export const msop = (
 
   for (let i = 0; i < parameters.num_pins; i++) {
     const { x, y } = getMsopCoords(parameters.num_pins, i + 1, w, p, pl)
-    pads.push(rectpad(i + 1, x, y, pl, pw, cornerRadius))
+    // Dual-row packages number counter-clockwise: down the left column, then
+    // UP the right column, so the last pin sits across from pin 1 (#677).
+    const half = Math.floor(parameters.num_pins / 2)
+    const pinNumber = i + 1 <= half ? i + 1 : half + (parameters.num_pins - i)
+    pads.push(rectpad(pinNumber, x, y, pl, pw, cornerRadius))
   }
 
   if (parameters.thermalpad) {

--- a/src/fn/son.ts
+++ b/src/fn/son.ts
@@ -54,7 +54,10 @@ export const son = (
 
   for (let i = 0; i < parameters.num_pins; i++) {
     const { x, y } = getSonPadCoord(parameters.num_pins, i + 1, w, p)
-    pads.push(rectpad(i + 1, x, y, pl, pw, cornerRadius))
+    // Counter-clockwise numbering: down the left column, up the right column (#677).
+    const half = Math.floor(parameters.num_pins / 2)
+    const pinNumber = i + 1 <= half ? i + 1 : half + (parameters.num_pins - i)
+    pads.push(rectpad(pinNumber, x, y, pl, pw, cornerRadius))
   }
 
   if (parameters.ep) {

--- a/tests/msop-son-ccw-numbering.test.ts
+++ b/tests/msop-son-ccw-numbering.test.ts
@@ -1,0 +1,36 @@
+import { test, expect } from "bun:test"
+import { fp } from "src/footprinter"
+
+test("msop and son number pins counter-clockwise (#677)", () => {
+  for (const name of ["msop8", "son8", "msop10"]) {
+    const pads = fp
+      .string(name)
+      .circuitJson()
+      .filter((el: any) => el.type === "pcb_smtpad") as any[]
+    const byPin = (n: string) =>
+      pads.find((p) => (p.port_hints ?? []).includes(n))
+    const count = pads.length
+    const half = count / 2
+
+    // left column runs top -> bottom as pins 1..half
+    for (let pin = 1; pin <= half; pin++) {
+      const pad = byPin(String(pin))!
+      expect(pad.x).toBeLessThan(0)
+      if (pin > 1) {
+        expect(pad.y).toBeLessThan(byPin(String(pin - 1))!.y)
+      }
+    }
+
+    // right column runs bottom -> top as pins half+1..count
+    for (let pin = half + 1; pin <= count; pin++) {
+      const pad = byPin(String(pin))!
+      expect(pad.x).toBeGreaterThan(0)
+      if (pin > half + 1) {
+        expect(pad.y).toBeGreaterThan(byPin(String(pin - 1))!.y)
+      }
+    }
+
+    // last pin sits across from pin 1
+    expect(byPin(String(count))!.y).toBeGreaterThan(0)
+  }
+})


### PR DESCRIPTION
Fixes #677

## What

`msop` and `son` numbered their right column top→bottom (same direction as the left), so `msop8`/`son8` put pin 5 top-right and pin 8 bottom-right — mirrored versus `soic8`, which numbers correctly. Dual-row packages are numbered **counter-clockwise**: pins 1..n/2 down the left column, then n/2+1..n **up** the right column, last pin across from pin 1.

The pad loops now reverse only the right-column assignment (position code untouched). Repro after the fix:

| footprint | pin n/2+1 | pin n |
|---|---|---|
| msop8 | (2.165, −0.975) bottom-right ✅ | (2.165, +0.975) top-right ✅ |
| son8 | (1.4, −0.75) ✅ | (1.4, +0.75) ✅ |
| msop10 | (2.165, −1) ✅ | (2.165, +1) ✅ |

## Verification

- Regression test asserts the full CCW ordering (left column y descending, right column y ascending, last pin top) for msop8, son8, msop10
- SVG snapshots updated; full suite 565/565 pass, biome clean