### PR TITLE
feat: pdip/spdip string aliases for the dip footprint

### DIFF
--- a/src/footprinter.ts
+++ b/src/footprinter.ts
@@ -570,23 +570,29 @@ export type Footprinter = {
 }
 
 const normalizeDefinition = (def: string): string => {
-  return def
-    .trim()
-    .replace(/^pinheader(?=[\d_]|$)/i, "pinrow")
-    .replace(/^d2pak(\d+)(?=_|$)/i, "d2pak_$1")
-    .replace(/^to-252(?:-(\d+))?(?=_|$)/i, (_, pins) =>
-      pins ? `to252_${pins}` : "to252",
-    )
-    .replace(/^to-263(?:-(\d+))?(?=_|$)/i, (_, pins) =>
-      pins ? `to263_${pins}` : "to263",
-    )
-    .replace(/^sot-23(?:-(\d+))?(?=_|$)/i, (_, pins) =>
-      pins ? `sot23_${pins}` : "sot23",
-    )
-    .replace(/^sot23-(\d+)(?=_|$)/i, "sot23_$1")
-    .replace(/^sot-223-(\d+)(?=_|$)/i, "sot223_$1")
-    .replace(/^to-220f-(\d+)(?=_|$)/i, "to220f_$1")
-    .replace(/^jst_(ph|sh|zh|xh)_(\d+)(?=_|$)/i, "jst$2_$1")
+  return (
+    def
+      .trim()
+      .replace(/^pinheader(?=[\d_]|$)/i, "pinrow")
+      .replace(/^d2pak(\d+)(?=_|$)/i, "d2pak_$1")
+      .replace(/^to-252(?:-(\d+))?(?=_|$)/i, (_, pins) =>
+        pins ? `to252_${pins}` : "to252",
+      )
+      .replace(/^to-263(?:-(\d+))?(?=_|$)/i, (_, pins) =>
+        pins ? `to263_${pins}` : "to263",
+      )
+      .replace(/^sot-23(?:-(\d+))?(?=_|$)/i, (_, pins) =>
+        pins ? `sot23_${pins}` : "sot23",
+      )
+      .replace(/^sot23-(\d+)(?=_|$)/i, "sot23_$1")
+      .replace(/^sot-223-(\d+)(?=_|$)/i, "sot223_$1")
+      .replace(/^to-220f-(\d+)(?=_|$)/i, "to220f_$1")
+      .replace(/^jst_(ph|sh|zh|xh)_(\d+)(?=_|$)/i, "jst$2_$1")
+      // PDIP/SPDIP are the same plastic/shouldered DIP land pattern the `dip`
+      // footprint already emits (KiCad DIP-8_W7.62mm).
+      .replace(/^(?:pdip|spdip)(\d+)(?=_|$)/i, "dip$1")
+      .replace(/^(?:pdip|spdip)(?=_|$)/i, "dip")
+  )
 }
 
 const normalizeMicrometerLengths = (value: string): string =>

--- a/tests/pdip-alias.test.ts
+++ b/tests/pdip-alias.test.ts
@@ -1,0 +1,23 @@
+import { test, expect } from "bun:test"
+import { fp } from "src/footprinter"
+
+test("pdip and spdip aliases render the standard DIP layout (#371)", () => {
+  for (const name of ["pdip8", "spdip8", "pdip16"]) {
+    const circuitJson = fp.string(name).circuitJson()
+    const pads = circuitJson.filter(
+      (el: any) => el.type === "pcb_plated_hole" || el.type === "pcb_smtpad",
+    )
+    const expected = Number.parseInt(name.replace(/\D/g, ""), 10)
+    expect(pads.length, `${name} should render ${expected} pads`).toBe(expected)
+  }
+
+  // same geometry as the equivalent dip footprint
+  const pdip = fp.string("pdip8").circuitJson()
+  const dip = fp.string("dip8").circuitJson()
+  const xs = (j: any) =>
+    j
+      .filter((el: any) => el.type === "pcb_plated_hole")
+      .map((el: any) => el.x)
+      .sort()
+  expect(xs(pdip)).toEqual(xs(dip))
+})


### PR DESCRIPTION
Fixes #371

## What

`pdip8` threw `Invalid footprint function, got "pdip"` while `dip8` rendered fine. PDIP-8 and the shouldered SPDIP variant use the same land pattern `dip` already emits (KiCad `DIP-8_W7.62mm`), so `normalizeDefinition` now rewrites `pdip`/`spdip` prefixes to `dip`, preserving the pin count and any trailing params:

- `pdip8` → 8 pads ✅ · `spdip8` → 8 pads ✅ · `pdip16` → 16 pads ✅
- Geometry identical to `dip8` (plated-hole x positions match exactly)

This is deliberately minimal vs the three larger open PRs — a two-line normalizer reusing the proven DIP layout.

## Verification

- `tests/pdip-alias.test.ts`: pad counts for pdip8/spdip8/pdip16 plus coordinate-identity with `dip8`
- Full suite: 565/565 pass, biome clean