### PR TITLE
test: expose the four courtyard-parity exemptions

### DIFF
--- a/tests/kicad-parity/qfn32_kicad_parity.test.ts
+++ b/tests/kicad-parity/qfn32_kicad_parity.test.ts
@@ -3,15 +3,23 @@ import { compareFootprinterVsKicad } from "../fixtures/compareFootprinterVsKicad
 import { convertCircuitJsonToPcbSvg } from "circuit-to-svg"
 
 test("parity/qfn32_thermalpad3.1x3.1mm", async () => {
-  const { avgRelDiff, combinedFootprintElements, booleanDifferenceSvg } =
-    await compareFootprinterVsKicad(
-      "qfn32_thermalpad3.1x3.1mm",
-      "Package_DFN_QFN.pretty/QFN-32-1EP_5x5mm_P0.5mm_EP3.1x3.1mm.circuit.json",
-    )
+  const {
+    avgRelDiff,
+    combinedFootprintElements,
+    booleanDifferenceSvg,
+    courtyardDiffPercent,
+  } = await compareFootprinterVsKicad(
+    "qfn32_thermalpad3.1x3.1mm",
+    "Package_DFN_QFN.pretty/QFN-32-1EP_5x5mm_P0.5mm_EP3.1x3.1mm.circuit.json",
+  )
 
   const svgContent = convertCircuitJsonToPcbSvg(combinedFootprintElements, {
     showCourtyards: true,
   })
+  // Courtyard is currently ~13% off KiCad (#731); asserted explicitly so the
+  // drift is visible in CI instead of hidden behind a stable snapshot.
+  expect(courtyardDiffPercent).toBeLessThan(14)
+
   expect(svgContent).toMatchSvgSnapshot(
     import.meta.path,
     "qfn32_thermalpad3.1x3.1mm",

--- a/tests/kicad-parity/soic20_kicad_parity.test.ts
+++ b/tests/kicad-parity/soic20_kicad_parity.test.ts
@@ -13,6 +13,9 @@ test("parity/soic20", async () => {
     "Package_SO.pretty/Infineon_SOIC-20W_7.6x12.8mm_P1.27mm.circuit.json",
   )
 
+  // Bespoke ceiling: measured ~15.3% off KiCad (#731) — the legsoutside
+  // courtyard variant differs from the KiCad land pattern. Tracked in #731;
+  // the other 84 parity footprints are held to <5%.
   expect(courtyardDiffPercent).toBeLessThan(16)
   const svgContent = convertCircuitJsonToPcbSvg(combinedFootprintElements, {
     showCourtyards: true,

--- a/tests/kicad-parity/soic24_kicad_parity.test.ts
+++ b/tests/kicad-parity/soic24_kicad_parity.test.ts
@@ -13,6 +13,9 @@ test("parity/soic24", async () => {
     "Package_SO.pretty/SOIC-24W_7.5x15.4mm_P1.27mm.circuit.json",
   )
 
+  // Bespoke ceiling: measured ~15.3% off KiCad (#731) — the legsoutside
+  // courtyard variant differs from the KiCad land pattern. Tracked in #731;
+  // the other 84 parity footprints are held to <5%.
   expect(courtyardDiffPercent).toBeLessThan(16)
   const svgContent = convertCircuitJsonToPcbSvg(combinedFootprintElements, {
     showCourtyards: true,

--- a/tests/kicad-parity/soic8_kicad_parity.test.ts
+++ b/tests/kicad-parity/soic8_kicad_parity.test.ts
@@ -3,11 +3,19 @@ import { compareFootprinterVsKicad } from "../fixtures/compareFootprinterVsKicad
 import { convertCircuitJsonToPcbSvg } from "circuit-to-svg"
 
 test("parity/soic8", async () => {
-  const { avgRelDiff, combinedFootprintElements, booleanDifferenceSvg } =
-    await compareFootprinterVsKicad(
-      "soic8_w3.9mm_p1.27mm_legsoutside",
-      "Package_SO.pretty/SOIC-8_3.9x4.9mm_P1.27mm.circuit.json",
-    )
+  const {
+    avgRelDiff,
+    combinedFootprintElements,
+    booleanDifferenceSvg,
+    courtyardDiffPercent,
+  } = await compareFootprinterVsKicad(
+    "soic8_w3.9mm_p1.27mm_legsoutside",
+    "Package_SO.pretty/SOIC-8_3.9x4.9mm_P1.27mm.circuit.json",
+  )
+
+  // Courtyard is currently ~14% off KiCad (#731); asserted explicitly so the
+  // drift is visible in CI instead of hidden behind a stable snapshot.
+  expect(courtyardDiffPercent).toBeLessThan(15)
 
   const svgContent = convertCircuitJsonToPcbSvg(combinedFootprintElements, {
     showCourtyards: true,


### PR DESCRIPTION
Addresses the visibility half of #731

## What

Per the issue's measurements, the four worst parity footprints were exactly the ones not held to a real bound. This makes every exemption explicit:

- **`soic8`** (measured 14.24% off) and **`qfn32`** (13.08%) previously asserted *only snapshots* — stably wrong passed silently. Both now carry explicit `toBeLessThan(15)` / `toBeLessThan(14)` ceiling assertions, so any growth in the drift fails CI loudly while the current state stays green.
- **`soic20`** / **`soic24`** keep their bespoke `16` ceilings but gain comments recording the measurements (~15.3%) and pointing at #731.

The geometry half (aligning these four to KiCad like the other 84) is deliberately left open pending your direction on whether the `legsoutside` variants are intentionally different.

## Verification

- All four parity tests pass with the new assertions; measured IoUs logged (SOIC-8 85.76%, QFN-32 86.92%)
- Full suite: 564/564 pass, biome clean