### PR TITLE
fix: zero pitch on quad-family footprints produces NaN pad coordinates (closes #871)

### DIFF
--- a/src/fn/quad.ts
+++ b/src/fn/quad.ts
@@ -122,7 +122,7 @@ export const quadTransform = <T extends z.infer<typeof base_quad_def>>(
     v.p = (horizontalPitch + verticalPitch) / 2
   }
 
-  if (!v.w && !v.h && v.p) {
+  if (!v.w && !v.h && v.p !== undefined) {
     // HACK: underspecified
     v.w = horizontal_pitch * (horizontal_side_pin_count + 4)
     v.h = vertical_pitch * (vertical_side_pin_count + 4)

--- a/tests/quad-zero-pitch.test.ts
+++ b/tests/quad-zero-pitch.test.ts
@@ -1,0 +1,21 @@
+import { test, expect } from "bun:test"
+import { fp } from "src/footprinter"
+
+test("zero pitch on a quad-family footprint does not produce NaN pad coordinates", () => {
+  for (const str of ["lcc_p0mm", "qfn16_p0mm"]) {
+    let soup: any[] | undefined
+    try {
+      soup = fp.string(str).circuitJson()
+    } catch {
+      // Explicitly zero pitch is a degenerate package. Throwing is acceptable,
+      // silently emitting NaN/null coordinates into circuit-json is not.
+      continue
+    }
+    const pads = soup.filter((e) => e.type === "pcb_smtpad")
+    expect(pads.length).toBeGreaterThan(0)
+    for (const pad of pads) {
+      expect(Number.isFinite(pad.x)).toBe(true)
+      expect(Number.isFinite(pad.y)).toBe(true)
+    }
+  }
+})


### PR DESCRIPTION
Closes #871

## Root cause

`quadTransform` in `src/fn/quad.ts` used a falsy check, `!v.p`, to decide whether a pitch value had already been provided before deriving width and height from it. An explicit pitch of zero (for example `lcc_p0mm` or `qfn16_p0mm`) is falsy in JavaScript even though it is a legitimate, explicitly provided value. The width/height derivation branch was skipped, so `v.w` and `v.h` stayed `undefined`. Downstream, `getQuadCoords` computed `x: -w / 2 - pcdfe + 0.1` with `w = undefined`, producing `NaN` pad coordinates. `JSON.stringify` turns `NaN` into `null`, so the returned circuit-json silently contained `x: null` with no error raised.

## Change

Changed the guard from `v.p` (truthy check) to `v.p !== undefined` (presence check), one line in `src/fn/quad.ts`. This makes an explicit zero pitch behave the same as any other explicitly provided pitch. Since a zero pitch produces a zero width and height package, which is a degenerate geometry, affected calls now throw a clear error from the existing rectangle bounds validation instead of silently returning `NaN`/`null` coordinates.

## Test added

Added `tests/quad-zero-pitch.test.ts`, a regression test covering `lcc_p0mm` and `qfn16_p0mm`. It asserts that any pads returned have finite x/y coordinates, and accepts a thrown error as a valid outcome for the degenerate zero-pitch case, but never accepts `NaN`/`null` coordinates.

Verified the test fails on the pre-fix code and passes after the fix:

```
# before fix (git stash of the quad.ts change)
bun test tests/quad-zero-pitch.test.ts
(fail) zero pitch on a quad-family footprint does not produce NaN pad coordinates
 0 pass
 1 fail

# after fix
bun test tests/quad-zero-pitch.test.ts
 1 pass
 0 fail
```

## Full test suite and typecheck

```
bun test
 565 pass
 0 fail
 3 snapshots, 1549 expect() calls
Ran 565 tests across 227 files.
```

```
bunx tsc --noEmit
```
This reports 450 pre-existing errors in test files (loose typing against circuit-json union types), identical in count before and after this change (verified against unmodified main). No new typecheck errors introduced by this fix.

This fix was developed with AI assistance (Claude).
